### PR TITLE
Moved test utils into a test-utils feature

### DIFF
--- a/.github/workflows/Validations.yml
+++ b/.github/workflows/Validations.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --all-features --verbose
     - name: Formatting validations
       run: cargo fmt -- --check
     - name: Clippy Validations

--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -9,6 +9,9 @@ license = "MIT"
 readme = "Readme.md"
 documentation = "https://kalldrexx.github.io/mmids/"
 
+[features]
+test-utils = []
+
 [dependencies]
 tokio = { version = "1.15", features = ["full"] }
 futures = "0.3"

--- a/mmids-core/src/lib.rs
+++ b/mmids-core/src/lib.rs
@@ -18,8 +18,8 @@ pub mod event_hub;
 pub mod http_api;
 pub mod net;
 pub mod reactors;
-#[cfg(test)]
-mod test_utils;
+#[cfg(feature = "test-utils")]
+pub mod test_utils;
 mod utils;
 pub mod workflows;
 


### PR DESCRIPTION
This allows for crates to be split up, while still retaining some of the test utilities that help keep tests simple