### PR TITLE
Flexible payload types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "mmids-core"
-version = "1.1.2"
+version = "2.0.0-dev.3"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mmids-core"
 description = "Powerful and user friendly live video server"
 authors = ["Matthew Shapiro <me@mshapiro.net>"]
-version = "1.1.2"
+version = "2.0.0-dev.3"
 edition = "2018"
 repository = "https://github.com/KallDrexx/mmids"
 license = "MIT"

--- a/mmids-core/src/workflows/metadata/keys.rs
+++ b/mmids-core/src/workflows/metadata/keys.rs
@@ -1,14 +1,23 @@
 use crate::workflows::metadata::MetadataValueType;
 use std::collections::HashMap;
 
+/// How much to shift a u16 in order to store/read the
 const VALUE_TYPE_SHIFT: u16 = 12;
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+/// Distinctly identifies a single metadata attribute that can have data stored for it.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct MetadataKey {
     pub(super) klv_id: u16,
     pub(super) value_type: MetadataValueType,
 }
 
+/// Creates distinct metadata keys for each unique combination of metadata name and value type.
+/// If the same name and type pair are registered on the same `MetadataKeyMap` instance, then those
+/// keys returned are guaranteed to be equal to each other.
+///
+/// Keys created between different instances of `MetadataKeyMap` are not guaranteed (nor likely)
+/// to be consistent. Therefore, keys should only be compared with keys created by the same map
+/// instance, and in most cases you probably only want one instance for the whole process.
 #[derive(Default)]
 pub struct MetadataKeyMap {
     name_to_key_map: HashMap<MetadataNameTypePair, MetadataKey>,
@@ -30,7 +39,15 @@ impl MetadataKey {
 }
 
 impl MetadataKeyMap {
-    pub fn get_key(&mut self, name: &'static str, value_type: MetadataValueType) -> MetadataKey {
+    /// Creates a new `MetadataKeyMap` instance
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Registers the supplied metadata name and value type pair with the key map. If this
+    /// pair has not been registered yet then a new `MetadataKey` will be generated and returned.
+    /// If the same pair has already been registered, then the pre-generated key will be returned
+    pub fn register(&mut self, name: &'static str, value_type: MetadataValueType) -> MetadataKey {
         let name_type_pair = MetadataNameTypePair { name, value_type };
         match self.name_to_key_map.get(&name_type_pair) {
             Some(key) => *key,
@@ -69,7 +86,7 @@ fn apply_value_type_to_klv_id(id: u16, value_type: MetadataValueType) -> u16 {
     };
 
     type_id <<= VALUE_TYPE_SHIFT;
-    id & type_id
+    id | type_id
 }
 
 fn value_type_from_klv_id(klv_id: u16) -> MetadataValueType {
@@ -86,5 +103,174 @@ fn value_type_from_klv_id(klv_id: u16) -> MetadataValueType {
         9 => MetadataValueType::Bool,
         10 => MetadataValueType::Bytes,
         x => panic!("Unknown value type id of {}", x),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_apply_u8_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::U8);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::U8);
+    }
+
+    #[test]
+    fn can_apply_u16_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::U16);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::U16);
+    }
+
+    #[test]
+    fn can_apply_u32_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::U32);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::U32);
+    }
+
+    #[test]
+    fn can_apply_u64_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::U64);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::U64);
+    }
+
+    #[test]
+    fn can_apply_i8_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::I8);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::I8);
+    }
+
+    #[test]
+    fn can_apply_i16_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::I16);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::I16);
+    }
+
+    #[test]
+    fn can_apply_i32_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::I32);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::I32);
+    }
+
+    #[test]
+    fn can_apply_i64_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::I64);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::I64);
+    }
+
+    #[test]
+    fn can_apply_bool_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::Bool);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::Bool);
+    }
+
+    #[test]
+    fn can_apply_bytes_value_type_to_klv_id() {
+        let original_id = 5;
+        let id = apply_value_type_to_klv_id(original_id, MetadataValueType::Bytes);
+        assert_ne!(
+            id, original_id,
+            "Applied id should not have been the same as the original id"
+        );
+
+        let value_type = value_type_from_klv_id(id);
+        assert_eq!(value_type, MetadataValueType::Bytes);
+    }
+
+    #[test]
+    fn same_name_type_pair_gets_same_key_returned() {
+        let name = "test123";
+
+        let mut map = MetadataKeyMap::default();
+        let key1 = map.register(name, MetadataValueType::U32);
+        let key2 = map.register(name, MetadataValueType::U32);
+
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn different_name_gets_different_keys_returned() {
+        let name1 = "test123";
+        let name2 = "3456";
+
+        let mut map = MetadataKeyMap::default();
+        let key1 = map.register(name1, MetadataValueType::Bool);
+        let key2 = map.register(name2, MetadataValueType::Bool);
+
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn different_type_gets_different_keys_returned() {
+        let name = "test123";
+
+        let mut map = MetadataKeyMap::default();
+        let key1 = map.register(name, MetadataValueType::Bool);
+        let key2 = map.register(name, MetadataValueType::U32);
+
+        assert_ne!(key1, key2);
     }
 }

--- a/mmids-core/src/workflows/metadata/keys.rs
+++ b/mmids-core/src/workflows/metadata/keys.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
 use crate::workflows::metadata::MetadataValueType;
+use std::collections::HashMap;
+
+const VALUE_TYPE_SHIFT: u16 = 12;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct MetadataKey {
@@ -10,7 +12,6 @@ pub struct MetadataKey {
 #[derive(Default)]
 pub struct MetadataKeyMap {
     name_to_key_map: HashMap<MetadataNameTypePair, MetadataKey>,
-    klv_id_to_value_type_map: HashMap<u16, MetadataValueType>,
     next_id: u16,
 }
 
@@ -20,16 +21,27 @@ struct MetadataNameTypePair {
     value_type: MetadataValueType,
 }
 
+impl MetadataKey {
+    pub(super) fn from_klv_id(klv_id: u16) -> Self {
+        let value_type = value_type_from_klv_id(klv_id);
+
+        MetadataKey {
+            klv_id,
+            value_type
+        }
+    }
+}
+
 impl MetadataKeyMap {
-    pub fn register(&mut self, name: &'static str, value_type: MetadataValueType) -> MetadataKey {
-        let name_type_pair = MetadataNameTypePair {name, value_type};
+    pub fn get_key(&mut self, name: &'static str, value_type: MetadataValueType) -> MetadataKey {
+        let name_type_pair = MetadataNameTypePair { name, value_type };
         match self.name_to_key_map.get(&name_type_pair) {
             Some(key) => *key,
             None => {
-                let id = self.next_id;
+                let id = apply_value_type_to_klv_id(self.next_id, value_type);
                 self.next_id = match self.next_id.checked_add(1) {
                     Some(num) => num,
-                    None => panic!("Too many items added to key map, only 65,535 are allowed"),
+                    None => panic!("Too many metadata key name and type pairs added to key map, only 4,095 are allowed"),
                 };
 
                 let key = MetadataKey {
@@ -38,20 +50,44 @@ impl MetadataKeyMap {
                 };
 
                 self.name_to_key_map.insert(name_type_pair, key);
-                self.klv_id_to_value_type_map.insert(key.klv_id, value_type);
 
                 key
             }
         }
     }
-
-    pub fn get_key(&self, name: &'static str, value_type: MetadataValueType) -> Option<MetadataKey> {
-        let name_type_pair = MetadataNameTypePair {name, value_type};
-        self.name_to_key_map.get(&name_type_pair).copied()
-    }
-
-    pub(super) fn get_type_for_klv_id(&self, klv_id: u16) -> Option<MetadataValueType> {
-        self.klv_id_to_value_type_map.get(&klv_id).copied()
-    }
 }
 
+fn apply_value_type_to_klv_id(id: u16, value_type: MetadataValueType) -> u16 {
+    let mut type_id = match value_type {
+        MetadataValueType::U8 => 1,
+        MetadataValueType::U16 => 2,
+        MetadataValueType::U32 => 3,
+        MetadataValueType::U64 => 4,
+        MetadataValueType::I8 => 5,
+        MetadataValueType::I16 => 6,
+        MetadataValueType::I32 => 7,
+        MetadataValueType::I64 => 8,
+        MetadataValueType::Bool => 9,
+        MetadataValueType::Bytes => 10,
+    };
+
+    type_id = type_id << VALUE_TYPE_SHIFT;
+    id & type_id
+}
+
+fn value_type_from_klv_id(klv_id: u16) -> MetadataValueType {
+    let value_type_id = klv_id >> VALUE_TYPE_SHIFT;
+    match value_type_id {
+        1 => MetadataValueType::U8,
+        2 => MetadataValueType::U16,
+        3 => MetadataValueType::U32,
+        4 => MetadataValueType::U64,
+        5 => MetadataValueType::I8,
+        6 => MetadataValueType::I16,
+        7 => MetadataValueType::I32,
+        8 => MetadataValueType::I64,
+        9 => MetadataValueType::Bool,
+        10 => MetadataValueType::Bytes,
+        x => panic!("Unknown value type id of {}", x),
+    }
+}

--- a/mmids-core/src/workflows/metadata/keys.rs
+++ b/mmids-core/src/workflows/metadata/keys.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+use crate::workflows::metadata::MetadataValueType;
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub struct MetadataKey {
+    pub(super) klv_id: u16,
+    pub(super) value_type: MetadataValueType,
+}
+
+#[derive(Default)]
+pub struct MetadataKeyMap {
+    name_to_key_map: HashMap<MetadataNameTypePair, MetadataKey>,
+    klv_id_to_value_type_map: HashMap<u16, MetadataValueType>,
+    next_id: u16,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct MetadataNameTypePair {
+    name: &'static str,
+    value_type: MetadataValueType,
+}
+
+impl MetadataKeyMap {
+    pub fn register(&mut self, name: &'static str, value_type: MetadataValueType) -> MetadataKey {
+        let key = MetadataNameTypePair {name, value_type};
+        let entry = self.name_to_key_map
+            .entry(key)
+            .or_insert_with(|| {
+                let id = self.next_id;
+                self.next_id = match self.next_id.checked_add(1) {
+                    Some(num) => num,
+                    None => panic!("Too many items added to key map, only 65,535 are allowed"),
+                };
+
+                MetadataKey {
+                    klv_id: id,
+                    value_type,
+                }
+            });
+
+        self.klv_id_to_value_type_map.insert(entry.klv_id, value_type);
+
+        *entry
+    }
+
+    pub(super) fn get_type_for_klv_id(&self, klv_id: u16) -> Option<MetadataValueType> {
+        self.klv_id_to_value_type_map.get(&klv_id).copied()
+    }
+}
+

--- a/mmids-core/src/workflows/metadata/keys.rs
+++ b/mmids-core/src/workflows/metadata/keys.rs
@@ -25,10 +25,7 @@ impl MetadataKey {
     pub(super) fn from_klv_id(klv_id: u16) -> Self {
         let value_type = value_type_from_klv_id(klv_id);
 
-        MetadataKey {
-            klv_id,
-            value_type
-        }
+        MetadataKey { klv_id, value_type }
     }
 }
 
@@ -71,7 +68,7 @@ fn apply_value_type_to_klv_id(id: u16, value_type: MetadataValueType) -> u16 {
         MetadataValueType::Bytes => 10,
     };
 
-    type_id = type_id << VALUE_TYPE_SHIFT;
+    type_id <<= VALUE_TYPE_SHIFT;
     id & type_id
 }
 

--- a/mmids-core/src/workflows/metadata/klv.rs
+++ b/mmids-core/src/workflows/metadata/klv.rs
@@ -1,7 +1,7 @@
-use anyhow::{Result, anyhow};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
-use crate::workflows::metadata::{MetadataKey, MetadataValue, MetadataValueType};
 use crate::workflows::metadata::keys::MetadataKeyMap;
+use crate::workflows::metadata::{MetadataKey, MetadataValue, MetadataValueType};
+use anyhow::{anyhow, Result};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 pub struct KlvItem {
     pub key: u16,
@@ -21,7 +21,6 @@ pub struct KlvIterator {
 
 impl KlvItem {
     pub fn from_metadata(key: MetadataKey, value: MetadataValue, buffer: &mut BytesMut) -> Self {
-        assert_eq!(key.value_type, value, "Value was not compatible with key's value type");
         let mut buffer = buffer.split_off(buffer.len());
         match value {
             MetadataValue::U8(num) => buffer.put_u8(num),
@@ -42,15 +41,100 @@ impl KlvItem {
         }
     }
 
-    pub fn into_metadata(mut self, key_map: &MetadataKeyMap) -> Option<(MetadataKey, MetadataValue)> {
+    pub fn into_metadata(
+        mut self,
+        key_map: &MetadataKeyMap,
+    ) -> Result<(MetadataKey, MetadataValue)> {
         let value_type = match key_map.get_type_for_klv_id(self.key) {
             Some(key) => key,
-            None => return None, // No idea how to map the value type, so this item is ignored
+            None => return Err(anyhow!("No value type found for key")),
         };
 
+        let key = MetadataKey {
+            klv_id: self.key,
+            value_type,
+        };
         match value_type {
             MetadataValueType::U8 => {
-                if self.
+                if self.value.is_empty() {
+                    Err(anyhow!("Not enough bytes for a u8"))
+                } else {
+                    Ok((key, MetadataValue::U8(self.value.get_u8())))
+                }
+            }
+
+            MetadataValueType::U16 => {
+                if self.value.len() < 2 {
+                    Err(anyhow!("Not enough bytes for a u16"))
+                } else {
+                    Ok((key, MetadataValue::U16(self.value.get_u16())))
+                }
+            }
+
+            MetadataValueType::U32 => {
+                if self.value.len() < 4 {
+                    Err(anyhow!("Not enough bytes for a u32"))
+                } else {
+                    Ok((key, MetadataValue::U32(self.value.get_u32())))
+                }
+            }
+
+            MetadataValueType::U64 => {
+                if self.value.len() < 8 {
+                    Err(anyhow!("Not enough bytes for a u64"))
+                } else {
+                    Ok((key, MetadataValue::U64(self.value.get_u64())))
+                }
+            }
+
+            MetadataValueType::I8 => {
+                if self.value.is_empty() {
+                    Err(anyhow!("Not enough bytes for a i8"))
+                } else {
+                    Ok((key, MetadataValue::I8(self.value.get_i8())))
+                }
+            }
+
+            MetadataValueType::I16 => {
+                if self.value.len() < 2 {
+                    Err(anyhow!("Not enough bytes for a i16"))
+                } else {
+                    Ok((key, MetadataValue::I16(self.value.get_i16())))
+                }
+            }
+
+            MetadataValueType::I32 => {
+                if self.value.len() < 4 {
+                    Err(anyhow!("Not enough bytes for a i32"))
+                } else {
+                    Ok((key, MetadataValue::I32(self.value.get_i32())))
+                }
+            }
+
+            MetadataValueType::I64 => {
+                if self.value.len() < 8 {
+                    Err(anyhow!("Not enough bytes for a i64"))
+                } else {
+                    Ok((key, MetadataValue::I64(self.value.get_i64())))
+                }
+            }
+
+            MetadataValueType::Bool => {
+                if self.value.is_empty() {
+                    Err(anyhow!("Not enough bytes for a bool"))
+                } else {
+                    let value = match self.value.get_u8() {
+                        0 => false,
+                        1 => true,
+                        x => return Err(anyhow!("Invalied boolean value of {x}")),
+                    };
+
+                    Ok((key, MetadataValue::Bool(value)))
+                }
+            }
+
+            MetadataValueType::Bytes => {
+                Ok((key, MetadataValue::Bytes(self.value)))
             }
         }
     }
@@ -59,7 +143,7 @@ impl KlvItem {
 impl KlvData {
     pub fn from_iter(
         buffer: &mut BytesMut,
-        iterator: impl Iterator<Item=KlvItem>,
+        iterator: impl Iterator<Item = KlvItem>,
     ) -> Result<Self> {
         let mut buffer = buffer.split_off(buffer.len());
         for item in iterator {
@@ -72,7 +156,9 @@ impl KlvData {
             buffer.put(item.value);
         }
 
-        Ok(KlvData {data: buffer.freeze()})
+        Ok(KlvData {
+            data: buffer.freeze(),
+        })
     }
 
     pub fn iter(&self) -> KlvIterator {

--- a/mmids-core/src/workflows/metadata/klv.rs
+++ b/mmids-core/src/workflows/metadata/klv.rs
@@ -1,0 +1,99 @@
+use anyhow::{Result, anyhow};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use crate::workflows::metadata::{MetadataKey, MetadataValue, MetadataValueType};
+use crate::workflows::metadata::keys::MetadataKeyMap;
+
+pub struct KlvItem {
+    pub key: u16,
+    pub value: Bytes,
+}
+
+#[derive(Clone)]
+pub struct KlvData {
+    data: Bytes,
+}
+
+/// Iterates through KLV data in order. This is a separate structure from `KlvData` to allow a
+/// single instance of `KlvData` to be iterated more than once.
+pub struct KlvIterator {
+    data: Bytes,
+}
+
+impl KlvItem {
+    pub fn from_metadata(key: MetadataKey, value: MetadataValue, buffer: &mut BytesMut) -> Self {
+        assert_eq!(key.value_type, value, "Value was not compatible with key's value type");
+        let mut buffer = buffer.split_off(buffer.len());
+        match value {
+            MetadataValue::U8(num) => buffer.put_u8(num),
+            MetadataValue::U16(num) => buffer.put_u16(num),
+            MetadataValue::U32(num) => buffer.put_u32(num),
+            MetadataValue::U64(num) => buffer.put_u64(num),
+            MetadataValue::I8(num) => buffer.put_i8(num),
+            MetadataValue::I16(num) => buffer.put_i16(num),
+            MetadataValue::I32(num) => buffer.put_i32(num),
+            MetadataValue::I64(num) => buffer.put_i64(num),
+            MetadataValue::Bool(value) => buffer.put_u8(if value { 1 } else { 0 }),
+            MetadataValue::Bytes(bytes) => buffer.put(bytes),
+        };
+
+        KlvItem {
+            key: key.klv_id,
+            value: buffer.freeze(),
+        }
+    }
+
+    pub fn into_metadata(mut self, key_map: &MetadataKeyMap) -> Option<(MetadataKey, MetadataValue)> {
+        let value_type = match key_map.get_type_for_klv_id(self.key) {
+            Some(key) => key,
+            None => return None, // No idea how to map the value type, so this item is ignored
+        };
+
+        match value_type {
+            MetadataValueType::U8 => {
+                if self.
+            }
+        }
+    }
+}
+
+impl KlvData {
+    pub fn from_iter(
+        buffer: &mut BytesMut,
+        iterator: impl Iterator<Item=KlvItem>,
+    ) -> Result<Self> {
+        let mut buffer = buffer.split_off(buffer.len());
+        for item in iterator {
+            if item.value.len() >= u16::MAX as usize {
+                return Err(anyhow!("Tlv value was too large"));
+            }
+
+            buffer.put_u16(item.key);
+            buffer.put_u16(item.value.len() as u16);
+            buffer.put(item.value);
+        }
+
+        Ok(KlvData {data: buffer.freeze()})
+    }
+
+    pub fn iter(&self) -> KlvIterator {
+        KlvIterator {
+            data: self.data.clone(),
+        }
+    }
+}
+
+impl Iterator for KlvIterator {
+    type Item = KlvItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        let key = self.data.get_u16();
+        let length = self.data.get_u16();
+        let value = self.data.split_to(length as usize);
+
+        Some(KlvItem { key, value })
+    }
+}

--- a/mmids-core/src/workflows/metadata/klv.rs
+++ b/mmids-core/src/workflows/metadata/klv.rs
@@ -1,5 +1,3 @@
-use crate::workflows::metadata::keys::MetadataKeyMap;
-use crate::workflows::metadata::{MetadataKey, MetadataValue, MetadataValueType};
 use anyhow::{anyhow, Result};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -8,7 +6,7 @@ pub struct KlvItem {
     pub value: Bytes,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct KlvData {
     data: Bytes,
 }
@@ -17,127 +15,6 @@ pub struct KlvData {
 /// single instance of `KlvData` to be iterated more than once.
 pub struct KlvIterator {
     data: Bytes,
-}
-
-impl KlvItem {
-    pub fn from_metadata(key: MetadataKey, value: MetadataValue, buffer: &mut BytesMut) -> Self {
-        let mut buffer = buffer.split_off(buffer.len());
-        match value {
-            MetadataValue::U8(num) => buffer.put_u8(num),
-            MetadataValue::U16(num) => buffer.put_u16(num),
-            MetadataValue::U32(num) => buffer.put_u32(num),
-            MetadataValue::U64(num) => buffer.put_u64(num),
-            MetadataValue::I8(num) => buffer.put_i8(num),
-            MetadataValue::I16(num) => buffer.put_i16(num),
-            MetadataValue::I32(num) => buffer.put_i32(num),
-            MetadataValue::I64(num) => buffer.put_i64(num),
-            MetadataValue::Bool(value) => buffer.put_u8(if value { 1 } else { 0 }),
-            MetadataValue::Bytes(bytes) => buffer.put(bytes),
-        };
-
-        KlvItem {
-            key: key.klv_id,
-            value: buffer.freeze(),
-        }
-    }
-
-    pub fn into_metadata(
-        mut self,
-        key_map: &MetadataKeyMap,
-    ) -> Result<(MetadataKey, MetadataValue)> {
-        let value_type = match key_map.get_type_for_klv_id(self.key) {
-            Some(key) => key,
-            None => return Err(anyhow!("No value type found for key")),
-        };
-
-        let key = MetadataKey {
-            klv_id: self.key,
-            value_type,
-        };
-        match value_type {
-            MetadataValueType::U8 => {
-                if self.value.is_empty() {
-                    Err(anyhow!("Not enough bytes for a u8"))
-                } else {
-                    Ok((key, MetadataValue::U8(self.value.get_u8())))
-                }
-            }
-
-            MetadataValueType::U16 => {
-                if self.value.len() < 2 {
-                    Err(anyhow!("Not enough bytes for a u16"))
-                } else {
-                    Ok((key, MetadataValue::U16(self.value.get_u16())))
-                }
-            }
-
-            MetadataValueType::U32 => {
-                if self.value.len() < 4 {
-                    Err(anyhow!("Not enough bytes for a u32"))
-                } else {
-                    Ok((key, MetadataValue::U32(self.value.get_u32())))
-                }
-            }
-
-            MetadataValueType::U64 => {
-                if self.value.len() < 8 {
-                    Err(anyhow!("Not enough bytes for a u64"))
-                } else {
-                    Ok((key, MetadataValue::U64(self.value.get_u64())))
-                }
-            }
-
-            MetadataValueType::I8 => {
-                if self.value.is_empty() {
-                    Err(anyhow!("Not enough bytes for a i8"))
-                } else {
-                    Ok((key, MetadataValue::I8(self.value.get_i8())))
-                }
-            }
-
-            MetadataValueType::I16 => {
-                if self.value.len() < 2 {
-                    Err(anyhow!("Not enough bytes for a i16"))
-                } else {
-                    Ok((key, MetadataValue::I16(self.value.get_i16())))
-                }
-            }
-
-            MetadataValueType::I32 => {
-                if self.value.len() < 4 {
-                    Err(anyhow!("Not enough bytes for a i32"))
-                } else {
-                    Ok((key, MetadataValue::I32(self.value.get_i32())))
-                }
-            }
-
-            MetadataValueType::I64 => {
-                if self.value.len() < 8 {
-                    Err(anyhow!("Not enough bytes for a i64"))
-                } else {
-                    Ok((key, MetadataValue::I64(self.value.get_i64())))
-                }
-            }
-
-            MetadataValueType::Bool => {
-                if self.value.is_empty() {
-                    Err(anyhow!("Not enough bytes for a bool"))
-                } else {
-                    let value = match self.value.get_u8() {
-                        0 => false,
-                        1 => true,
-                        x => return Err(anyhow!("Invalied boolean value of {x}")),
-                    };
-
-                    Ok((key, MetadataValue::Bool(value)))
-                }
-            }
-
-            MetadataValueType::Bytes => {
-                Ok((key, MetadataValue::Bytes(self.value)))
-            }
-        }
-    }
 }
 
 impl KlvData {

--- a/mmids-core/src/workflows/metadata/klv.rs
+++ b/mmids-core/src/workflows/metadata/klv.rs
@@ -1,13 +1,23 @@
+//! Key-length-value encoding of byte data. Allows storing a set of data in a single contiguous
+//! `Bytes` collection, enabling the storing of different types of data in re-usable memory
+//! arenas, and being cheap to clone.
+
 use anyhow::{anyhow, Result};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
+/// An individual Key-Length-Value item
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct KlvItem {
+    /// Identifies the item in the KLV set. This should be unique for each logical type of
+    /// data being stored, although the key can be re-used if multiple values for the same type
+    /// of data exists (e.g. an array of values of the same type).
     pub key: u16,
     pub value: Bytes,
 }
 
+/// Storage of the KLV data
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct KlvData {
+pub struct KlvStore {
     data: Bytes,
 }
 
@@ -17,7 +27,13 @@ pub struct KlvIterator {
     data: Bytes,
 }
 
-impl KlvData {
+impl KlvStore {
+    /// Creates a new `KlvData` structure from an iterator of items. Items are stored in the order
+    /// they are returned in the iterator.
+    ///
+    /// This function takes in a  buffer that it should use to fill. This enables re-use of an
+    /// existing buffer arena to  prevent allocations for this data if we can fit it in an existing
+    /// and unused `BytesMut` storage.
     pub fn from_iter(
         buffer: &mut BytesMut,
         iterator: impl Iterator<Item = KlvItem>,
@@ -33,11 +49,13 @@ impl KlvData {
             buffer.put(item.value);
         }
 
-        Ok(KlvData {
+        Ok(KlvStore {
             data: buffer.freeze(),
         })
     }
 
+    /// Creates a new iterator that goes through the items in the KLV store. This is guaranteed
+    /// to be in the same order that they were added in.
     pub fn iter(&self) -> KlvIterator {
         KlvIterator {
             data: self.data.clone(),
@@ -58,5 +76,48 @@ impl Iterator for KlvIterator {
         let value = self.data.split_to(length as usize);
 
         Some(KlvItem { key, value })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_create_and_read_items_from_klv_store() {
+        let items = [
+            KlvItem {
+                key: 1,
+                value: Bytes::from_static(&[1, 2, 3]),
+            },
+            KlvItem {
+                key: 202,
+                value: Bytes::from_static(&[4, 5]),
+            },
+            KlvItem {
+                key: 1,
+                value: Bytes::from_static(&[6]),
+            },
+        ];
+
+        let store = KlvStore::from_iter(&mut BytesMut::new(), items.iter().cloned()).unwrap();
+        let mut iterator = store.iter();
+
+        assert_eq!(
+            iterator.next(),
+            Some(items[0].clone()),
+            "Unexpected first item"
+        );
+        assert_eq!(
+            iterator.next(),
+            Some(items[1].clone()),
+            "Unexpected second item"
+        );
+        assert_eq!(
+            iterator.next(),
+            Some(items[2].clone()),
+            "Unexpected third item"
+        );
+        assert_eq!(iterator.next(), None, "Expected no other items");
     }
 }

--- a/mmids-core/src/workflows/metadata/mod.rs
+++ b/mmids-core/src/workflows/metadata/mod.rs
@@ -1,10 +1,11 @@
 mod keys;
 mod klv;
 
-use crate::workflows::metadata::keys::MetadataKey;
 use crate::workflows::metadata::klv::{KlvData, KlvItem};
 use bytes::{BufMut, Bytes, BytesMut};
 use tracing::error;
+
+pub use keys::{MetadataKey, MetadataKeyMap};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MediaPayloadMetadata {
@@ -12,7 +13,18 @@ pub struct MediaPayloadMetadata {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum MetadataValueType {U8, U16, U32, U64, I8, I16, I32, I64, Bytes, Bool}
+pub enum MetadataValueType {
+    U8,
+    U16,
+    U32,
+    U64,
+    I8,
+    I16,
+    I32,
+    I64,
+    Bytes,
+    Bool,
+}
 
 #[derive(Debug)]
 pub enum MetadataValue {
@@ -35,7 +47,9 @@ pub struct MetadataEntry {
 
 #[derive(thiserror::Error, Debug)]
 pub enum MetadataEntryError {
-    #[error("Metadata entry's value was {value:?} but the type was expected to be {expected_type:?}")]
+    #[error(
+        "Metadata entry's value was {value:?} but the type was expected to be {expected_type:?}"
+    )]
     ValueDoesNotMatchType {
         value: MetadataValue,
         expected_type: MetadataValueType,
@@ -46,10 +60,7 @@ pub enum MetadataEntryError {
 }
 
 impl MediaPayloadMetadata {
-    pub fn new(
-        entries: impl Iterator<Item = MetadataEntry>,
-        buffer: &mut BytesMut,
-    ) -> Self {
+    pub fn new(entries: impl Iterator<Item = MetadataEntry>, buffer: &mut BytesMut) -> Self {
         let mut klv_buffer = buffer.split_off(buffer.len());
         let klv_items = entries.map(|e| KlvItem {
             key: e.key.klv_id,
@@ -62,12 +73,10 @@ impl MediaPayloadMetadata {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = MetadataEntry> {
-        self.data
-            .iter()
-            .map(|item| MetadataEntry {
-                key: MetadataKey::from_klv_id(item.key),
-                raw_value: item.value
-            })
+        self.data.iter().map(|item| MetadataEntry {
+            key: MetadataKey::from_klv_id(item.key),
+            raw_value: item.value,
+        })
     }
 }
 
@@ -83,7 +92,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::U8 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::U8
+                        expected_type: MetadataValueType::U8,
                     });
                 }
 
@@ -94,7 +103,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::U16 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::U16
+                        expected_type: MetadataValueType::U16,
                     });
                 }
 
@@ -105,7 +114,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::U32 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::U32
+                        expected_type: MetadataValueType::U32,
                     });
                 }
 
@@ -116,7 +125,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::U64 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::U64
+                        expected_type: MetadataValueType::U64,
                     });
                 }
 
@@ -127,7 +136,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::I8 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::I8
+                        expected_type: MetadataValueType::I8,
                     });
                 }
 
@@ -138,7 +147,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::I16 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::I16
+                        expected_type: MetadataValueType::I16,
                     });
                 }
 
@@ -149,7 +158,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::I32 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::I32
+                        expected_type: MetadataValueType::I32,
                     });
                 }
 
@@ -160,7 +169,7 @@ impl MetadataEntry {
                 if key.value_type != MetadataValueType::I64 {
                     return Err(MetadataEntryError::ValueDoesNotMatchType {
                         value,
-                        expected_type: MetadataValueType::I64
+                        expected_type: MetadataValueType::I64,
                     });
                 }
 

--- a/mmids-core/src/workflows/metadata/mod.rs
+++ b/mmids-core/src/workflows/metadata/mod.rs
@@ -20,6 +20,11 @@ pub use keys::{MetadataKey, MetadataKeyMap};
 /// buffer that persists across media payloads, which should eventually cause each media payload
 /// to no longer require its own heap allocation and efficiently re-use unreserved parts of the
 /// memory buffer.
+///
+/// The trade off for cloning and allocation efficiency is that iterating through metadata is an
+/// O(N) operation, which means if you need to look for a specific type of metadata you may have to
+/// iterate through all other metadata items first. This tradeoff was deemed acceptable for now
+/// with the idea that each payload would only have a small amount of metadata attached to it.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MediaPayloadMetadataCollection {
     data: KlvStore,

--- a/mmids-core/src/workflows/metadata/mod.rs
+++ b/mmids-core/src/workflows/metadata/mod.rs
@@ -1,17 +1,31 @@
+//! This module contains functionality for storing and retrieving metadata about individual
+//! media payloads.
+
 mod keys;
 mod klv;
 
-use crate::workflows::metadata::klv::{KlvData, KlvItem};
-use bytes::{BufMut, Bytes, BytesMut};
+use crate::workflows::metadata::klv::{KlvItem, KlvStore};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tracing::error;
 
 pub use keys::{MetadataKey, MetadataKeyMap};
 
+/// Allows storing arbitrary attributes and value pairs that can are relevant to an individual
+/// media payload/packet. These are stored in a relatively efficient way to make it cheap to
+/// clone and attempt to minimize per-packet heap allocations. Once a metadata collection has been
+/// created it cannot be modified.
+///
+/// The metadata currently relies on being passed in a `BytesMut` buffer that it will use for
+/// storage. This allows for the creator of media payloads to maintain an arena style memory
+/// buffer that persists across media payloads, which should eventually cause each media payload
+/// to no longer require its own heap allocation and efficiently re-use unreserved parts of the
+/// memory buffer.
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct MediaPayloadMetadata {
-    data: KlvData,
+pub struct MediaPayloadMetadataCollection {
+    data: KlvStore,
 }
 
+/// Declares what type of data is being stored in a metadata entry
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum MetadataValueType {
     U8,
@@ -26,7 +40,8 @@ pub enum MetadataValueType {
     Bool,
 }
 
-#[derive(Debug)]
+/// An actual value stored in a metadata entry
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MetadataValue {
     U8(u8),
     U16(u16),
@@ -40,11 +55,14 @@ pub enum MetadataValue {
     Bool(bool),
 }
 
+/// An individual key/value paired stored as metadata
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MetadataEntry {
     key: MetadataKey,
     raw_value: Bytes,
 }
 
+/// Errors that can occur when creating a metadata entry
 #[derive(thiserror::Error, Debug)]
 pub enum MetadataEntryError {
     #[error(
@@ -59,7 +77,10 @@ pub enum MetadataEntryError {
     ValueTooLarge,
 }
 
-impl MediaPayloadMetadata {
+impl MediaPayloadMetadataCollection {
+    /// Creates a new collection of metadata based on the provided entries. A buffer is passed in
+    /// which can allow the creators of the collection to maintain an arena to reduce allocations
+    /// for each new metadata collection that is created.
     pub fn new(entries: impl Iterator<Item = MetadataEntry>, buffer: &mut BytesMut) -> Self {
         let mut klv_buffer = buffer.split_off(buffer.len());
         let klv_items = entries.map(|e| KlvItem {
@@ -67,11 +88,12 @@ impl MediaPayloadMetadata {
             value: e.raw_value,
         });
 
-        let klv_data = KlvData::from_iter(&mut klv_buffer, klv_items).unwrap();
+        let klv_data = KlvStore::from_iter(&mut klv_buffer, klv_items).unwrap();
 
-        MediaPayloadMetadata { data: klv_data }
+        MediaPayloadMetadataCollection { data: klv_data }
     }
 
+    /// Provides a non-consuming iterator that allows reading of entries within the collection
     pub fn iter(&self) -> impl Iterator<Item = MetadataEntry> {
         self.data.iter().map(|item| MetadataEntry {
             key: MetadataKey::from_klv_id(item.key),
@@ -81,6 +103,7 @@ impl MediaPayloadMetadata {
 }
 
 impl MetadataEntry {
+    /// Creates a new media metadata payload entry for the key and value pair
     pub fn new(
         key: MetadataKey,
         value: MetadataValue,
@@ -207,5 +230,242 @@ impl MetadataEntry {
             key,
             raw_value: buffer.freeze(),
         })
+    }
+
+    /// Retrieves the value from the entry
+    pub fn get_value(&self) -> MetadataValue {
+        // Clone to not advance the original buffer
+        let mut buffer = self.raw_value.clone();
+
+        // We shouldn't have to worry about validation as consumers should have only been able
+        // to create an entry via a `new()` call, and therefore we are sure the raw value is
+        // correct and matches.
+        match self.key.value_type {
+            MetadataValueType::U8 => MetadataValue::U8(buffer.get_u8()),
+            MetadataValueType::U16 => MetadataValue::U16(buffer.get_u16()),
+            MetadataValueType::U32 => MetadataValue::U32(buffer.get_u32()),
+            MetadataValueType::U64 => MetadataValue::U64(buffer.get_u64()),
+            MetadataValueType::I8 => MetadataValue::I8(buffer.get_i8()),
+            MetadataValueType::I16 => MetadataValue::I16(buffer.get_i16()),
+            MetadataValueType::I32 => MetadataValue::I32(buffer.get_i32()),
+            MetadataValueType::I64 => MetadataValue::I64(buffer.get_i64()),
+            MetadataValueType::Bytes => MetadataValue::Bytes(buffer),
+            MetadataValueType::Bool => match buffer.get_u8() {
+                0 => MetadataValue::Bool(false),
+                1 => MetadataValue::Bool(true),
+                x => panic!("Invalid boolean value of {}", x),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn can_create_and_get_value_from_u8_metadata_entry() {
+        let value = MetadataValue::U8(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::U8,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_u16_metadata_entry() {
+        let value = MetadataValue::U16(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::U16,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_u32_metadata_entry() {
+        let value = MetadataValue::U32(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::U32,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_u64_metadata_entry() {
+        let value = MetadataValue::U64(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::U64,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_i8_metadata_entry() {
+        let value = MetadataValue::I8(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::I8,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_i16_metadata_entry() {
+        let value = MetadataValue::I16(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::I16,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_i32_metadata_entry() {
+        let value = MetadataValue::I32(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::I32,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_i64_metadata_entry() {
+        let value = MetadataValue::I64(5);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::I64,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_bool_metadata_entry() {
+        let value = MetadataValue::Bool(true);
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::Bool,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_get_value_from_bytes_metadata_entry() {
+        let value = MetadataValue::Bytes(Bytes::from_static(&[1, 2, 3, 4, 5]));
+        let key = MetadataKey {
+            klv_id: 15,
+            value_type: MetadataValueType::Bytes,
+        };
+        let entry = MetadataEntry::new(key, value.clone(), &mut BytesMut::new()).unwrap();
+        let returned_value = entry.get_value();
+
+        assert_eq!(returned_value, value);
+    }
+
+    #[test]
+    fn can_create_and_retrieve_media_payload_metadata() {
+        let mut buffer = BytesMut::new();
+        let mut map = MetadataKeyMap::default();
+
+        let keys = [
+            map.register("first", MetadataValueType::U8),
+            map.register("second", MetadataValueType::Bool),
+            map.register("third", MetadataValueType::Bytes),
+        ];
+
+        let values = [
+            MetadataValue::U8(5),
+            MetadataValue::Bool(true),
+            MetadataValue::Bytes(Bytes::from_static(&[1, 2, 3, 4])),
+        ];
+
+        let entries = vec![
+            MetadataEntry::new(keys[0], values[0].clone(), &mut buffer).unwrap(),
+            MetadataEntry::new(keys[1], values[1].clone(), &mut buffer).unwrap(),
+            MetadataEntry::new(keys[2], values[2].clone(), &mut buffer).unwrap(),
+        ];
+
+        let metadata =
+            MediaPayloadMetadataCollection::new(entries.clone().into_iter(), &mut buffer);
+        let mut iterator = metadata.iter();
+
+        assert_eq!(
+            iterator.next(),
+            Some(entries[0].clone()),
+            "Unexpected first entry"
+        );
+        assert_eq!(
+            iterator.next(),
+            Some(entries[1].clone()),
+            "Unexpected second entry"
+        );
+        assert_eq!(
+            iterator.next(),
+            Some(entries[2].clone()),
+            "Unexpected third entry"
+        );
+        assert_eq!(iterator.next(), None, "Unexpected fourth entry");
+    }
+
+    #[test]
+    fn media_payload_metadata_can_be_iterated_multiple_times() {
+        let mut buffer = BytesMut::new();
+        let mut map = MetadataKeyMap::default();
+
+        let keys = [
+            map.register("first", MetadataValueType::U8),
+            map.register("second", MetadataValueType::Bool),
+        ];
+
+        let values = [MetadataValue::U8(5), MetadataValue::Bool(true)];
+
+        let entries = vec![
+            MetadataEntry::new(keys[0], values[0].clone(), &mut buffer).unwrap(),
+            MetadataEntry::new(keys[1], values[1].clone(), &mut buffer).unwrap(),
+        ];
+
+        let metadata = MediaPayloadMetadataCollection::new(entries.into_iter(), &mut buffer);
+
+        assert_eq!(
+            metadata.iter().count(),
+            2,
+            "Unexpected number of items in iterator"
+        );
+        assert_eq!(
+            metadata.iter().count(),
+            2,
+            "Unexpected number of items in iterator"
+        );
     }
 }

--- a/mmids-core/src/workflows/metadata/mod.rs
+++ b/mmids-core/src/workflows/metadata/mod.rs
@@ -1,0 +1,57 @@
+mod keys;
+mod klv;
+
+use crate::workflows::metadata::keys::MetadataKey;
+use crate::workflows::metadata::klv::{KlvData, KlvItem};
+use bytes::{Bytes, BytesMut};
+
+#[derive(Clone)]
+pub struct MediaPayloadMetadata {
+    data: KlvData,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum MetadataValueType {U8, U16, U32, U64, I8, I16, I32, I64, Bytes, Bool}
+
+#[derive(Debug)]
+pub enum MetadataValue {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    Bytes(Bytes),
+    Bool(bool),
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum MetadataCreationError {
+    #[error("Metadata entry had a value that could not be stored")]
+    InvalidValue,
+}
+
+
+impl MediaPayloadMetadata {
+    pub fn new(
+        key_value_pairs: impl Iterator<Item = (MetadataKey, MetadataValue)>,
+        buffer: &mut BytesMut,
+    ) -> Result<Self, MetadataCreationError> {
+        let mut buffer = buffer.split_off(buffer.len());
+        let iterator = key_value_pairs
+            .map(|(k, v)| KlvItem::from_metadata(k, v, &mut buffer));
+
+        let klv_data = KlvData::from_iter(&mut buffer, iterator)
+            .map_err(|_| MetadataCreationError::InvalidValue)?;
+
+        Ok(MediaPayloadMetadata { data: klv_data })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (MetadataKey, MetadataValue)> {
+        self.data
+            .iter()
+            .map(|item| (MetadataKey(item.key), MetadataValue { data: item.value }))
+    }
+}

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -15,9 +15,11 @@ use crate::codecs::{AudioCodec, VideoCodec};
 use crate::{StreamId, VideoTimestamp};
 use bytes::Bytes;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 pub use runner::{WorkflowState, WorkflowStepState};
+use crate::workflows::metadata::MediaPayloadMetadata;
 
 /// Notification about media coming across a specific stream
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -64,4 +66,22 @@ pub enum MediaNotificationContent {
 
     /// New stream metadata
     Metadata { data: HashMap<String, String> },
+
+    /// An individual payload as part of this media stream
+    MediaPayload {
+        /// High level description of the type of payload contained.
+        codec: Arc<String>,
+
+        /// How long since an unidentified epoch is this payload valid for. It cannot be assumed
+        /// that this is necessarily the duration from stream begin, but can be used to determine
+        /// when this payload should be decoded in comparison to payloads that came in before and
+        /// after it.
+        timestamp: Duration,
+
+        /// Metadata that's only specific to this individual payload
+        metadata: MediaPayloadMetadata,
+
+        /// Actual payload bytes
+        data: Bytes,
+    }
 }

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::workflows::metadata::MediaPayloadMetadata;
+use crate::workflows::metadata::MediaPayloadMetadataCollection;
 pub use runner::{WorkflowState, WorkflowStepState};
 
 /// Notification about media coming across a specific stream
@@ -79,7 +79,7 @@ pub enum MediaNotificationContent {
         timestamp: Duration,
 
         /// Metadata that's only specific to this individual payload
-        metadata: MediaPayloadMetadata,
+        metadata: MediaPayloadMetadataCollection,
 
         /// Actual payload bytes
         data: Bytes,

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod definitions;
 pub mod manager;
+pub mod metadata;
 mod runner;
 pub mod steps;
 

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -18,8 +18,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub use runner::{WorkflowState, WorkflowStepState};
 use crate::workflows::metadata::MediaPayloadMetadata;
+pub use runner::{WorkflowState, WorkflowStepState};
 
 /// Notification about media coming across a specific stream
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -83,5 +83,15 @@ pub enum MediaNotificationContent {
 
         /// Actual payload bytes
         data: Bytes,
-    }
+
+        /// Determines if this payload is a high priority packet that is required for decoding.
+        /// This is meant for sequence headers (for h264 and aac as an example) where later packets
+        /// cannot be decoded without it. These high priority packets are rarely re-sent, and
+        /// therefore this flag lets us know to cache them when this is `true`.
+        ///
+        /// Flagging this as `true` will cause these packets to be  cached, potentially until a
+        /// `StreamDisconnected` signal occurs, and therefore this must only be set for rare
+        /// high priority packets (i.e. not for key frames in video).
+        is_required_for_decoding: bool,
+    },
 }

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -596,6 +596,7 @@ impl Actor {
                 MediaNotificationContent::Video { .. } => (),
                 MediaNotificationContent::Audio { .. } => (),
                 MediaNotificationContent::Metadata { .. } => (),
+                MediaNotificationContent::MediaPayload { .. } => (),
                 MediaNotificationContent::NewIncomingStream { .. } => {
                     if !self.active_streams.contains_key(&media.stream_id) {
                         // Since this is the first time we've gotten a new incoming stream

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -699,6 +699,17 @@ impl Actor {
                         Operation::Ignore
                     }
                 }
+
+                MediaNotificationContent::MediaPayload {
+                    is_required_for_decoding,
+                    ..
+                } => {
+                    if *is_required_for_decoding {
+                        Operation::Add
+                    } else {
+                        Operation::Ignore
+                    }
+                }
             };
 
             match operation {

--- a/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
+++ b/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
@@ -223,6 +223,12 @@ impl BasicTranscodeStep {
                 }
             }
 
+            MediaNotificationContent::MediaPayload { .. } => {
+                if let Some(transcode) = self.active_transcodes.get(&media.stream_id) {
+                    let _ = transcode.media_sender.send(media.content.clone());
+                }
+            }
+
             MediaNotificationContent::Metadata { .. } => (),
         }
     }

--- a/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
@@ -188,13 +188,11 @@ impl RtmpServerConnectionHandler {
             match result {
                 FutureResult::Disconnected => {
                     info!("Connection disconnected");
-                    dbg!("1");
                     break;
                 }
 
                 FutureResult::RtmpServerEndpointGone => {
                     error!("Connection's rtmp server endpoint is gone");
-                    dbg!("2");
                     break;
                 }
 
@@ -203,7 +201,6 @@ impl RtmpServerConnectionHandler {
                         .push(internal_futures::wait_for_incoming_bytes(receiver).boxed());
 
                     if self.handle_bytes(bytes).is_err() {
-                        dbg!("3");
                         break;
                     }
                 }
@@ -224,13 +221,9 @@ impl RtmpServerConnectionHandler {
             }
 
             if self.force_disconnect {
-                dbg!("abc");
                 break;
             }
         }
-
-        let test = self.futures.len();
-        dbg!(test);
 
         info!("Rtmp server handler closing");
     }

--- a/mmids-rtmp/src/rtmp_server/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/mod.rs
@@ -349,6 +349,8 @@ impl TryFrom<MediaNotificationContent> for RtmpEndpointMediaData {
                 timestamp: RtmpTimestamp::new(timestamp.as_millis() as u32),
                 is_sequence_header,
             }),
+
+            MediaNotificationContent::MediaPayload { .. } => unimplemented!(),
         }
     }
 }

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
@@ -468,6 +468,8 @@ impl RtmpWatchStep {
 
                     let _ = self.media_channel.send(rtmp_media);
                 }
+
+                MediaNotificationContent::MediaPayload { .. } => unimplemented!(),
             }
         }
     }


### PR DESCRIPTION
Currently the `MediaNotificationContent` enumeration has several issues preventing wider use:

1. They have two variants, one for audio and one for video, which makes it hard to route non-AV media payloads through the workflow engine
2. The audio and video variants have specific per-packet metadata as properties, which may not be relevant for all audio or video payloads that flow through the system (for example, not all audio codecs have sequence headers).  Similarly, there are times when consumers of mmids would want to be able to add new metadata information on a per packet basis, and the current structure doesn't allow that.
3. The audio and video codecs are currently defined as a closed enumeration, which makes it impossible for other consumers to use a codec the core library doesn't have an entry for.

To fix all of these a new variant was created, the `MediaNotificationContent::MediaPayload`.  This allows a generic payload to be produced with a flexible set of per-packet metadata, and an `Arc<String>` for codecs to allow consumers to define their own.

The per-packet metadata collection has been designed to reduce allocations required as the application runs, by allowing systems that create media notifications to maintain an arena style memory buffer that the metadata collections can be used.  This should cause allocations to be heavy at the start, but start to slow down and be amortized as the arena starts having more free space to put new metadata collections into it.

The Audio and Video variants will be removed in a follow-up PR.