### PR TITLE
Renamed `codec` field to `payload_type` for media payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "mmids-core"
-version = "2.0.0-dev.3"
+version = "2.0.0-dev.5"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mmids-core"
 description = "Powerful and user friendly live video server"
 authors = ["Matthew Shapiro <me@mshapiro.net>"]
-version = "2.0.0-dev.4"
+version = "2.0.0-dev.5"
 edition = "2018"
 repository = "https://github.com/KallDrexx/mmids"
 license = "MIT"

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -69,8 +69,11 @@ pub enum MediaNotificationContent {
 
     /// An individual payload as part of this media stream
     MediaPayload {
-        /// High level description of the type of payload contained.
-        codec: Arc<String>,
+        /// High level description of the format of bytes contained in the payload. May be the name
+        /// of a codec (e.g. `aac`) but may also be more specific, such as a codec specific stream
+        /// format (e.g. `h264 avc`). The identifiers for these payload types will need to be
+        /// agreed upon, so different components can know when they support different payloads.
+        payload_type: Arc<String>,
 
         /// How long since an unidentified epoch is this payload valid for. It cannot be assumed
         /// that this is necessarily the duration from stream begin, but can be used to determine


### PR DESCRIPTION
There is the need for the byte structure in media payloads to be differentiated by more than just the high level format, e.g. h264 AVC vs h264 byte streams. This made the term `codec` ambiguous.