### PR TITLE
Added media type enumeration.

### DIFF
--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mmids-core"
 description = "Powerful and user friendly live video server"
 authors = ["Matthew Shapiro <me@mshapiro.net>"]
-version = "2.0.0-dev.5"
+version = "2.0.0-dev.6"
 edition = "2018"
 repository = "https://github.com/KallDrexx/mmids"
 license = "MIT"

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -21,6 +21,14 @@ use std::time::Duration;
 use crate::workflows::metadata::MediaPayloadMetadataCollection;
 pub use runner::{WorkflowState, WorkflowStepState};
 
+/// Identifies the category of media contained within a payload
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MediaType {
+    Audio,
+    Video,
+    Other,
+}
+
 /// Notification about media coming across a specific stream
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MediaNotification {
@@ -69,6 +77,13 @@ pub enum MediaNotificationContent {
 
     /// An individual payload as part of this media stream
     MediaPayload {
+        /// High level categorization of the media contained in this payload. Can be used by
+        /// consumers who do not necessarily care about how the bytes in the payload are formatted,
+        /// but just cares about categorization and metadata of the payload. E.g. an SFU may only
+        /// care about audio packets and their energy level metadata, but not what codec the audio
+        /// is formatted in.
+        media_type: MediaType,
+
         /// High level description of the format of bytes contained in the payload. May be the name
         /// of a codec (e.g. `aac`) but may also be more specific, such as a codec specific stream
         /// format (e.g. `h264 avc`). The identifiers for these payload types will need to be


### PR DESCRIPTION
This gives us a high level categorization of a media payload that can be used by components that doesn't care about the format of the bytes, but only specific metadata and if ti's an audio, video, or other packet.