### PR TITLE
Reduce heap allocations from string clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "mmids-core"
-version = "2.0.0-dev.5"
+version = "2.0.0-dev.7"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mmids-core"
 description = "Powerful and user friendly live video server"
 authors = ["Matthew Shapiro <me@mshapiro.net>"]
-version = "2.0.0-dev.6"
+version = "2.0.0-dev.7"
 edition = "2018"
 repository = "https://github.com/KallDrexx/mmids"
 license = "MIT"

--- a/mmids-core/src/http_api/handlers/get_workflow_details.rs
+++ b/mmids-core/src/http_api/handlers/get_workflow_details.rs
@@ -9,6 +9,7 @@ use hyper::http::HeaderValue;
 use hyper::{Body, Error, Request, Response, StatusCode};
 use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot::channel;
@@ -68,7 +69,7 @@ impl RouteHandler for GetWorkflowDetailsHandler {
         let _ = self.manager.send(WorkflowManagerRequest {
             request_id,
             operation: WorkflowManagerRequestOperation::GetWorkflowDetails {
-                name: workflow_name,
+                name: Arc::new(workflow_name),
                 response_channel: sender,
             },
         });

--- a/mmids-core/src/http_api/handlers/list_workflows.rs
+++ b/mmids-core/src/http_api/handlers/list_workflows.rs
@@ -79,7 +79,9 @@ impl RouteHandler for ListWorkflowsHandler {
 
         let response = response
             .into_iter()
-            .map(|x| WorkflowListItemResponse { name: x.name })
+            .map(|x| WorkflowListItemResponse {
+                name: x.name.to_string(),
+            })
             .collect::<Vec<_>>();
         let json = match serde_json::to_string_pretty(&response) {
             Ok(json) => json,

--- a/mmids-core/src/http_api/handlers/stop_workflow.rs
+++ b/mmids-core/src/http_api/handlers/stop_workflow.rs
@@ -5,6 +5,7 @@ use crate::workflows::manager::{WorkflowManagerRequest, WorkflowManagerRequestOp
 use async_trait::async_trait;
 use hyper::{Body, Error, Request, Response, StatusCode};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
 
@@ -30,7 +31,7 @@ impl RouteHandler for StopWorkflowHandler {
         request_id: String,
     ) -> Result<Response<Body>, Error> {
         let workflow_name = match path_parameters.get("workflow") {
-            Some(value) => value.to_string(),
+            Some(value) => Arc::new(value.to_string()),
             None => {
                 error!("Get workflow endpoint called without a 'workflow' path parameter");
                 let mut response = Response::default();

--- a/mmids-core/src/lib.rs
+++ b/mmids-core/src/lib.rs
@@ -7,6 +7,7 @@ extern crate pest;
 extern crate pest_derive;
 
 use std::num::Wrapping;
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::error;
 
@@ -30,7 +31,7 @@ pub mod workflows;
 /// a workflow has an ffmpeg transcoding step in the workflow (e.g. to add a watermark), when
 /// ffmpeg pushes the video back in it will keep the same identifier.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct StreamId(pub String);
+pub struct StreamId(pub Arc<String>);
 
 /// Represents timestamps relevant to video data.  Contains the decoding time stamp (dts) and
 /// presentation time stamp (dts).

--- a/mmids-core/src/net/mod.rs
+++ b/mmids-core/src/net/mod.rs
@@ -4,6 +4,7 @@ use cidr_utils::cidr::{IpCidr, Ipv4Cidr};
 use std::fmt::Formatter;
 use std::hash::{Hash, Hasher};
 use std::net::Ipv4Addr;
+use std::sync::Arc;
 use thiserror::Error;
 
 pub mod tcp;
@@ -11,7 +12,7 @@ pub mod tcp;
 /// A unique identifier for any given TCP connection, or unique UDP client.  If a TCP client
 /// disconnects and reconnects it will be seen with a brand new connection id
 #[derive(Clone, Debug, Eq)]
-pub struct ConnectionId(pub String);
+pub struct ConnectionId(pub Arc<String>);
 
 impl std::fmt::Display for ConnectionId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/mmids-core/src/net/tcp/listener.rs
+++ b/mmids-core/src/net/tcp/listener.rs
@@ -107,7 +107,7 @@ async fn listen(params: ListenerParams, _self_disconnection_signal: UnboundedRec
                     }
                 };
 
-                let connection_id = ConnectionId(Uuid::new_v4().to_string());
+                let connection_id = ConnectionId(Arc::new(Uuid::new_v4().to_string()));
                 tokio::spawn(handle_new_connection(socket, client_info, response_channel.clone(), port, connection_id, tls.clone()));
             },
 

--- a/mmids-core/src/reactors/executors/mod.rs
+++ b/mmids-core/src/reactors/executors/mod.rs
@@ -3,6 +3,7 @@ pub mod simple_http_executor;
 use crate::workflows::definitions::WorkflowDefinition;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Contains the result from a reactor execution request about a stream
@@ -18,7 +19,7 @@ pub struct ReactorExecutionResult {
 /// Performs a request for workflow information on behalf of a reactor
 pub trait ReactorExecutor {
     /// Requests the definition of a workflow based on a stream name
-    fn get_workflow(&self, stream_name: String) -> BoxFuture<'static, ReactorExecutionResult>;
+    fn get_workflow(&self, stream_name: Arc<String>) -> BoxFuture<'static, ReactorExecutionResult>;
 }
 
 /// Allows generating a reactor executor using parameters from a reactor definition

--- a/mmids-core/src/reactors/mod.rs
+++ b/mmids-core/src/reactors/mod.rs
@@ -11,6 +11,7 @@ pub mod manager;
 mod reactor;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 pub use reactor::{start_reactor, ReactorRequest, ReactorWorkflowUpdate};
@@ -20,7 +21,7 @@ pub use reactor::{start_reactor, ReactorRequest, ReactorWorkflowUpdate};
 pub struct ReactorDefinition {
     /// The name of the reactor. Used by endpoints and workflow steps to identify which workflow
     /// they want to interact with.
-    pub name: String,
+    pub name: Arc<String>,
 
     /// The name of the query executor this reactor should use to perform queries
     pub executor: String,

--- a/mmids-core/src/workflows/definitions.rs
+++ b/mmids-core/src/workflows/definitions.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 /// Identifier representing the type of the workflow step being defined
 #[derive(Clone, Hash, Debug, Eq, PartialEq)]
@@ -17,7 +18,7 @@ pub struct WorkflowStepDefinition {
 /// The definition of a workflow and the steps (in order) it contains
 #[derive(Clone, Debug)]
 pub struct WorkflowDefinition {
-    pub name: String,
+    pub name: Arc<String>,
     pub routed_by_reactor: bool,
     pub steps: Vec<WorkflowStepDefinition>,
 }

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -46,7 +46,7 @@ pub enum MediaNotificationContent {
     /// should prepare for media data to start coming through
     NewIncomingStream {
         /// The name for the stream that's being published
-        stream_name: String,
+        stream_name: Arc<String>,
     },
 
     /// Announces that this stream's source has disconnected and will no longer be sending any

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -103,7 +103,7 @@ struct StreamDetails {
 }
 
 struct Actor {
-    name: String,
+    name: Arc<String>,
     steps_by_definition_id: HashMap<u64, Box<dyn WorkflowStep>>,
     active_steps: Vec<u64>,
     pending_steps: Vec<u64>,

--- a/mmids-core/src/workflows/runner/test_context.rs
+++ b/mmids-core/src/workflows/runner/test_context.rs
@@ -24,7 +24,7 @@ pub struct TestContext {
 impl TestContext {
     pub fn new() -> Self {
         let (input_media_sender, input_media_receiver) = channel(MediaNotification {
-            stream_id: StreamId("invalid".to_string()),
+            stream_id: StreamId(Arc::new("invalid".to_string())),
             content: MediaNotificationContent::StreamDisconnected,
         });
 
@@ -55,7 +55,7 @@ impl TestContext {
             .expect("Failed to register output step");
 
         let definition = WorkflowDefinition {
-            name: "abc".to_string(),
+            name: Arc::new("abc".to_string()),
             routed_by_reactor: false,
             steps: vec![
                 WorkflowStepDefinition {

--- a/mmids-core/src/workflows/runner/tests.rs
+++ b/mmids-core/src/workflows/runner/tests.rs
@@ -216,7 +216,7 @@ async fn workflow_passes_media_from_one_step_to_the_next() {
     context
         .media_sender
         .send(MediaNotification {
-            stream_id: StreamId("abc".to_string()),
+            stream_id: StreamId(Arc::new("abc".to_string())),
             content: StreamDisconnected,
         })
         .expect("Failed to send media notification to step");
@@ -224,7 +224,7 @@ async fn workflow_passes_media_from_one_step_to_the_next() {
     let response = test_utils::expect_mpsc_response(&mut context.media_receiver).await;
     assert_eq!(
         response.stream_id,
-        StreamId("abc".to_string()),
+        StreamId(Arc::new("abc".to_string())),
         "Unexpected stream id"
     );
 
@@ -253,7 +253,7 @@ async fn media_sent_to_workflow_flows_through_steps() {
             request_id: "".to_string(),
             operation: WorkflowRequestOperation::MediaNotification {
                 media: MediaNotification {
-                    stream_id: StreamId("abc".to_string()),
+                    stream_id: StreamId(Arc::new("abc".to_string())),
                     content: StreamDisconnected,
                 },
             },
@@ -263,7 +263,7 @@ async fn media_sent_to_workflow_flows_through_steps() {
     let response = test_utils::expect_mpsc_response(&mut context.media_receiver).await;
     assert_eq!(
         response.stream_id,
-        StreamId("abc".to_string()),
+        StreamId(Arc::new("abc".to_string())),
         "Unexpected stream id"
     );
 
@@ -295,7 +295,7 @@ async fn steps_in_active_workflow_are_pending() {
     let mut params = HashMap::new(); // parameters will give it a new id
     params.insert("a".to_string(), Some("b".to_string()));
     let definition = WorkflowDefinition {
-        name: "abc".to_string(),
+        name: Arc::new("abc".to_string()),
         routed_by_reactor: false,
         steps: vec![WorkflowStepDefinition {
             step_type: WorkflowStepType("output".to_string()),
@@ -375,7 +375,7 @@ async fn new_pending_steps_replace_active_steps_when_pending_steps_get_active_st
     params2.insert("c".to_string(), None);
 
     let definition = WorkflowDefinition {
-        name: "abc".to_string(),
+        name: Arc::new("abc".to_string()),
         routed_by_reactor: false,
         steps: vec![
             WorkflowStepDefinition {
@@ -470,7 +470,7 @@ async fn channel_closed_after_shutdown() {
 async fn workflow_in_error_state_if_factory_cant_find_step() {
     let factory = Arc::new(WorkflowStepFactory::new());
     let definition = WorkflowDefinition {
-        name: "abc".to_string(),
+        name: Arc::new("abc".to_string()),
         routed_by_reactor: false,
         steps: vec![WorkflowStepDefinition {
             step_type: WorkflowStepType("input".to_string()),
@@ -522,7 +522,7 @@ async fn workflow_in_error_state_if_updated_steps_arent_registered_with_factory(
     tokio::time::sleep(Duration::from_millis(10)).await;
 
     let definition = WorkflowDefinition {
-        name: "abc".to_string(),
+        name: Arc::new("abc".to_string()),
         routed_by_reactor: false,
         steps: vec![WorkflowStepDefinition {
             step_type: WorkflowStepType("output2".to_string()),

--- a/mmids-ffmpeg/src/endpoint.rs
+++ b/mmids-ffmpeg/src/endpoint.rs
@@ -386,7 +386,7 @@ impl Actor {
         }
 
         args.push("-i".to_string());
-        args.push(params.input.clone());
+        args.push(params.input.to_string());
 
         args.push("-vcodec".to_string());
         match &params.video_transcode {

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
@@ -211,7 +211,7 @@ mod tests {
                 read_in_real_time: true,
                 input: stream_name.to_string(),
                 target: TargetParams::Rtmp {
-                    url: stream_id.0.clone(),
+                    url: stream_id.0.to_string(),
                 },
             }
         }
@@ -230,7 +230,7 @@ mod tests {
                 param_generator: Arc::new(Box::new(TestParamGenerator)),
             };
 
-            let handler = generator.generate(StreamId("test".to_string()));
+            let handler = generator.generate(StreamId(Arc::new("test".to_string())));
             TestContext {
                 handler,
                 ffmpeg: receiver,

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
@@ -22,6 +22,7 @@ use mmids_rtmp::rtmp_server::{
     StreamKeyRegistration,
 };
 use mmids_rtmp::utils::video_timestamp_from_rtmp_data;
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -42,9 +43,9 @@ struct FfmpegPullStep {
     ffmpeg_endpoint: UnboundedSender<FfmpegEndpointRequest>,
     rtmp_endpoint: UnboundedSender<RtmpEndpointRequest>,
     status: StepStatus,
-    rtmp_app: String,
+    rtmp_app: Arc<String>,
     pull_location: String,
-    stream_name: String,
+    stream_name: Arc<String>,
     ffmpeg_id: Option<Uuid>,
     active_stream_id: Option<StreamId>,
 }
@@ -93,14 +94,14 @@ impl StepGenerator for FfmpegPullStepGenerator {
         };
 
         let stream_name = match definition.parameters.get(STREAM_NAME) {
-            Some(Some(value)) => value.clone(),
+            Some(Some(value)) => Arc::new(value.clone()),
             _ => return Err(Box::new(StepStartupError::NoStreamNameSpecified)),
         };
 
         let step = FfmpegPullStep {
             definition: definition.clone(),
             status: StepStatus::Created,
-            rtmp_app: format!("ffmpeg-pull-{}", definition.get_id()),
+            rtmp_app: Arc::new(format!("ffmpeg-pull-{}", definition.get_id())),
             ffmpeg_endpoint: self.ffmpeg_endpoint.clone(),
             rtmp_endpoint: self.rtmp_endpoint.clone(),
             pull_location: location,

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
@@ -17,6 +17,7 @@ use mmids_core::workflows::steps::{
 use mmids_core::StreamId;
 use mmids_rtmp::rtmp_server::RtmpEndpointRequest;
 use mmids_rtmp::workflow_steps::external_stream_reader::ExternalStreamReader;
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
@@ -80,7 +81,7 @@ impl StepGenerator for FfmpegRtmpPushStepGenerator {
             FfmpegHandlerGenerator::new(self.ffmpeg_endpoint.clone(), Box::new(param_generator));
 
         let (reader, mut futures) = ExternalStreamReader::new(
-            format!("ffmpeg-rtmp-push-{}", definition.get_id()),
+            Arc::new(format!("ffmpeg-rtmp-push-{}", definition.get_id())),
             self.rtmp_endpoint.clone(),
             Box::new(handler_generator),
         );

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
@@ -21,6 +21,7 @@ use mmids_rtmp::rtmp_server::{
 use rml_rtmp::sessions::StreamMetadata;
 use rml_rtmp::time::RtmpTimestamp;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
@@ -304,9 +305,9 @@ async fn rtmp_watch_registration_raised_on_new_stream() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -317,7 +318,7 @@ async fn rtmp_watch_registration_raised_on_new_stream() {
         } => {
             assert_eq!(
                 rtmp_stream_key,
-                StreamKeyRegistration::Exact("abc".to_string()),
+                StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
                 "Unexpected stream key"
             );
         }
@@ -332,9 +333,9 @@ async fn rtmp_publish_registration_raised_after_watch_accepted() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -347,7 +348,7 @@ async fn rtmp_publish_registration_raised_after_watch_accepted() {
         } => {
             assert_eq!(
                 rtmp_stream_key,
-                StreamKeyRegistration::Exact("abc".to_string()),
+                StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
                 "Unexpected stream key"
             );
         }
@@ -362,9 +363,9 @@ async fn ffmpeg_request_raised_after_publish_accepted() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -388,9 +389,9 @@ async fn h264_with_preset_passed_to_ffmpeg() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -413,9 +414,9 @@ async fn video_copy_passed_to_ffmpeg() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -436,9 +437,9 @@ async fn aac_acodec_passed_to_ffmpeg() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -459,9 +460,9 @@ async fn copy_acodec_passed_to_ffmpeg() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -486,9 +487,9 @@ async fn size_passed_to_ffmpeg() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -512,9 +513,9 @@ async fn bitrate_passed_to_ffmpeg() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -532,9 +533,9 @@ async fn ffmpeg_always_told_to_read_in_real_time() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -554,9 +555,9 @@ async fn ffmpeg_instructed_to_read_from_rtmp() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -584,9 +585,9 @@ async fn if_ffmpeg_process_stops_unexpectedly_it_starts_again_with_same_id_and_p
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -614,9 +615,9 @@ fn stream_started_notification_passed_through_immediately() {
     context
         .step_context
         .assert_media_passed_through(MediaNotification {
-            stream_id: StreamId("abc".to_string()),
+            stream_id: StreamId(Arc::new("abc".to_string())),
             content: MediaNotificationContent::NewIncomingStream {
-                stream_name: "abc".to_string(),
+                stream_name: Arc::new("abc".to_string()),
             },
         });
 }
@@ -629,7 +630,7 @@ fn disconnection_notification_passed_through_immediately() {
     context
         .step_context
         .assert_media_passed_through(MediaNotification {
-            stream_id: StreamId("abc".to_string()),
+            stream_id: StreamId(Arc::new("abc".to_string())),
             content: MediaNotificationContent::StreamDisconnected,
         });
 }
@@ -641,7 +642,7 @@ fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: MediaNotificationContent::Metadata {
                 data: HashMap::new(),
             },
@@ -656,7 +657,7 @@ fn video_notification_passed_as_input_does_not_get_passed_as_output() {
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: MediaNotificationContent::Video {
                 data: Bytes::from(vec![1, 2]),
                 codec: VideoCodec::H264,
@@ -678,7 +679,7 @@ fn audio_notification_passed_as_input_does_not_get_passed_as_output() {
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: MediaNotificationContent::Audio {
                 data: Bytes::from(vec![1, 2]),
                 codec: AudioCodec::Aac,
@@ -694,9 +695,9 @@ async fn video_packet_sent_to_watcher_media_channel() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -705,7 +706,7 @@ async fn video_packet_sent_to_watcher_media_channel() {
     let _ffmpeg_results = context.process_ffmpeg_event().await;
 
     let media = MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::Video {
             data: Bytes::from(vec![1, 2]),
             codec: VideoCodec::H264,
@@ -721,7 +722,7 @@ async fn video_packet_sent_to_watcher_media_channel() {
     context.step_context.execute_with_media(media.clone());
 
     let response = test_utils::expect_mpsc_response(&mut media_channel).await;
-    assert_eq!(&response.stream_key, "abc", "Unexpected stream key");
+    assert_eq!(response.stream_key.as_str(), "abc", "Unexpected stream key");
     assert_eq!(
         response.data,
         RtmpEndpointMediaData::try_from(media.content).unwrap(),
@@ -735,9 +736,9 @@ async fn audio_packet_sent_to_watcher_media_channel() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -746,7 +747,7 @@ async fn audio_packet_sent_to_watcher_media_channel() {
     let _ffmpeg_results = context.process_ffmpeg_event().await;
 
     let media = MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::Audio {
             data: Bytes::from(vec![1, 2]),
             codec: AudioCodec::Aac,
@@ -758,7 +759,7 @@ async fn audio_packet_sent_to_watcher_media_channel() {
     context.step_context.execute_with_media(media.clone());
 
     let response = test_utils::expect_mpsc_response(&mut media_channel).await;
-    assert_eq!(&response.stream_key, "abc", "Unexpected stream key");
+    assert_eq!(response.stream_key.as_str(), "abc", "Unexpected stream key");
     assert_eq!(
         response.data,
         RtmpEndpointMediaData::try_from(media.content).unwrap(),
@@ -772,9 +773,9 @@ async fn metadata_packet_sent_to_watcher_media_channel() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -783,7 +784,7 @@ async fn metadata_packet_sent_to_watcher_media_channel() {
     let _ffmpeg_results = context.process_ffmpeg_event().await;
 
     let media = MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::Metadata {
             data: HashMap::new(),
         },
@@ -793,7 +794,7 @@ async fn metadata_packet_sent_to_watcher_media_channel() {
     context.step_context.execute_pending_notifications().await;
 
     let response = test_utils::expect_mpsc_response(&mut media_channel).await;
-    assert_eq!(&response.stream_key, "abc", "Unexpected stream key");
+    assert_eq!(response.stream_key.as_str(), "abc", "Unexpected stream key");
     assert_eq!(
         response.data,
         RtmpEndpointMediaData::try_from(media.content).unwrap(),
@@ -807,9 +808,9 @@ async fn video_packet_with_other_stream_id_not_sent_to_watcher_media_channel() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -818,7 +819,7 @@ async fn video_packet_with_other_stream_id_not_sent_to_watcher_media_channel() {
     let _ffmpeg_results = context.process_ffmpeg_event().await;
 
     let media = MediaNotification {
-        stream_id: StreamId("test".to_string()),
+        stream_id: StreamId(Arc::new("test".to_string())),
         content: MediaNotificationContent::Video {
             data: Bytes::from(vec![1, 2]),
             codec: VideoCodec::H264,
@@ -839,9 +840,9 @@ async fn video_packet_from_publisher_passed_as_media_output() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -851,7 +852,7 @@ async fn video_packet_from_publisher_passed_as_media_output() {
 
     publish_channel
         .send(RtmpEndpointPublisherMessage::NewVideoData {
-            publisher: ConnectionId("connection".to_string()),
+            publisher: ConnectionId(Arc::new("connection".to_string())),
             data: Bytes::from(vec![1, 2, 3]),
             codec: VideoCodec::H264,
             timestamp: RtmpTimestamp::new(5),
@@ -871,7 +872,8 @@ async fn video_packet_from_publisher_passed_as_media_output() {
 
     let media = &context.step_context.media_outputs[0];
     assert_eq!(
-        media.stream_id.0, "abc",
+        media.stream_id.0.as_str(),
+        "abc",
         "Expected media to have original stream id"
     );
 
@@ -901,9 +903,9 @@ async fn audio_packet_from_publisher_passed_as_media_output() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -913,7 +915,7 @@ async fn audio_packet_from_publisher_passed_as_media_output() {
 
     publish_channel
         .send(RtmpEndpointPublisherMessage::NewAudioData {
-            publisher: ConnectionId("connection".to_string()),
+            publisher: ConnectionId(Arc::new("connection".to_string())),
             data: Bytes::from(vec![1, 2, 3]),
             codec: AudioCodec::Aac,
             timestamp: RtmpTimestamp::new(5),
@@ -931,7 +933,8 @@ async fn audio_packet_from_publisher_passed_as_media_output() {
 
     let media = &context.step_context.media_outputs[0];
     assert_eq!(
-        media.stream_id.0, "abc",
+        media.stream_id.0.as_str(),
+        "abc",
         "Expected media to have original stream id"
     );
 
@@ -958,9 +961,9 @@ async fn metadata_packet_from_publisher_passed_as_media_output() {
     let mut context = TestContext::new(definition).unwrap();
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId("abc".to_string()),
+        stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
-            stream_name: "def".to_string(),
+            stream_name: Arc::new("def".to_string()),
         },
     });
 
@@ -970,7 +973,7 @@ async fn metadata_packet_from_publisher_passed_as_media_output() {
 
     publish_channel
         .send(RtmpEndpointPublisherMessage::StreamMetadataChanged {
-            publisher: ConnectionId("connection".to_string()),
+            publisher: ConnectionId(Arc::new("connection".to_string())),
             metadata: StreamMetadata::new(),
         })
         .expect("Failed to send video message");
@@ -985,7 +988,8 @@ async fn metadata_packet_from_publisher_passed_as_media_output() {
 
     let media = &context.step_context.media_outputs[0];
     assert_eq!(
-        media.stream_id.0, "abc",
+        media.stream_id.0.as_str(),
+        "abc",
         "Expected media to have original stream id"
     );
 

--- a/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
+++ b/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
@@ -19,6 +19,7 @@ use mmids_core::workflows::steps::{
 use mmids_core::workflows::{MediaNotification, MediaNotificationContent};
 use mmids_core::StreamId;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
@@ -36,7 +37,7 @@ pub struct BasicTranscodeStepGenerator {
 struct ActiveTranscode {
     media_sender: UnboundedSender<MediaNotificationContent>,
     transcode_process_id: Uuid,
-    stream_name: String,
+    stream_name: Arc<String>,
 }
 
 struct BasicTranscodeStep {
@@ -154,7 +155,7 @@ impl BasicTranscodeStep {
     fn start_transcode(
         &mut self,
         stream_id: StreamId,
-        stream_name: String,
+        stream_name: Arc<String>,
         outputs: &mut StepOutputs,
     ) {
         if self.active_transcodes.contains_key(&stream_id) {

--- a/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
@@ -14,6 +14,7 @@ use mmids_core::net::ConnectionId;
 use mmids_core::StreamId;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 pub enum FutureResult {
@@ -30,7 +31,7 @@ pub enum FutureResult {
 
     PublishingRegistrantGone {
         port: u16,
-        app: String,
+        app: Arc<String>,
         stream_key: StreamKeyRegistration,
     },
 
@@ -48,15 +49,15 @@ pub enum FutureResult {
 
     WatcherRegistrantGone {
         port: u16,
-        app: String,
+        app: Arc<String>,
         stream_key: StreamKeyRegistration,
     },
 
     WatcherMediaDataReceived {
         data: RtmpEndpointMediaData,
         port: u16,
-        app: String,
-        stream_key: String,
+        app: Arc<String>,
+        stream_key: Arc<String>,
         stream_key_registration: StreamKeyRegistration,
         receiver: UnboundedReceiver<RtmpEndpointMediaMessage>,
     },
@@ -109,7 +110,7 @@ pub struct StreamKeyConnections {
 pub struct RtmpAppMapping {
     pub publisher_registrants: HashMap<StreamKeyRegistration, PublishingRegistrant>,
     pub watcher_registrants: HashMap<StreamKeyRegistration, WatcherRegistrant>,
-    pub active_stream_keys: HashMap<String, StreamKeyConnections>,
+    pub active_stream_keys: HashMap<Arc<String>, StreamKeyConnections>,
 }
 
 #[derive(PartialEq, Eq)]
@@ -141,23 +142,23 @@ pub enum ConnectionState {
     None,
 
     WaitingForPublishValidation {
-        rtmp_app: String,
-        stream_key: String,
+        rtmp_app: Arc<String>,
+        stream_key: Arc<String>,
     },
 
     WaitingForWatchValidation {
-        rtmp_app: String,
-        stream_key: String,
+        rtmp_app: Arc<String>,
+        stream_key: Arc<String>,
     },
 
     Publishing {
-        rtmp_app: String,
-        stream_key: String,
+        rtmp_app: Arc<String>,
+        stream_key: Arc<String>,
     },
 
     Watching {
-        rtmp_app: String,
-        stream_key: String,
+        rtmp_app: Arc<String>,
+        stream_key: Arc<String>,
     },
 }
 
@@ -169,7 +170,7 @@ pub struct Connection {
 }
 
 pub struct PortMapping {
-    pub rtmp_applications: HashMap<String, RtmpAppMapping>,
+    pub rtmp_applications: HashMap<Arc<String>, RtmpAppMapping>,
     pub status: PortStatus,
     pub connections: HashMap<ConnectionId, Connection>,
     pub tls: bool,

--- a/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
@@ -11,6 +11,7 @@ use mmids_core::codecs::{AudioCodec, VideoCodec};
 use mmids_core::test_utils;
 use rml_rtmp::sessions::{ClientSessionEvent, StreamMetadata};
 use rml_rtmp::time::RtmpTimestamp;
+use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
 
 mod rtmp_client;
@@ -29,7 +30,7 @@ async fn can_register_for_specific_port_for_publishers() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender,
         })
@@ -57,7 +58,7 @@ async fn can_register_with_tls_enabled() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender,
         })
@@ -85,7 +86,7 @@ async fn endpoint_publisher_receives_failed_when_port_rejected() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender,
         })
@@ -113,7 +114,7 @@ async fn multiple_requests_for_same_port_only_sends_one_request_to_socket_manage
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender,
         })
@@ -135,7 +136,7 @@ async fn multiple_requests_for_same_port_only_sends_one_request_to_socket_manage
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app2".to_string(),
+            rtmp_app: Arc::new("app2".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender2,
         })
@@ -163,7 +164,7 @@ async fn second_publisher_rejected_on_same_app_when_both_any_stream_key() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender,
         })
@@ -185,7 +186,7 @@ async fn second_publisher_rejected_on_same_app_when_both_any_stream_key() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender2,
         })
@@ -211,8 +212,8 @@ async fn second_publisher_rejected_on_same_app_and_same_exact_key() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             message_channel: sender,
         })
         .expect("Endpoint request failed to send");
@@ -233,8 +234,8 @@ async fn second_publisher_rejected_on_same_app_and_same_exact_key() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             message_channel: sender2,
         })
         .expect("2nd endpoint request failed to send");
@@ -259,7 +260,7 @@ async fn second_publisher_rejected_on_same_app_when_first_request_is_for_any_key
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender,
         })
@@ -281,8 +282,8 @@ async fn second_publisher_rejected_on_same_app_when_first_request_is_for_any_key
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             message_channel: sender2,
         })
         .expect("2nd endpoint request failed to send");
@@ -307,8 +308,8 @@ async fn second_publisher_rejected_on_same_app_when_first_request_is_for_specifi
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             message_channel: sender,
         })
         .expect("Endpoint request failed to send");
@@ -329,7 +330,7 @@ async fn second_publisher_rejected_on_same_app_when_first_request_is_for_specifi
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender2,
         })
@@ -355,8 +356,8 @@ async fn second_publisher_accepted_on_same_app_on_different_exact_keys() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             message_channel: sender,
         })
         .expect("Endpoint request failed to send");
@@ -377,8 +378,8 @@ async fn second_publisher_accepted_on_same_app_on_different_exact_keys() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("def".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("def".to_string())),
             message_channel: sender2,
         })
         .expect("2nd endpoint request failed to send");
@@ -403,7 +404,7 @@ async fn can_register_for_specific_port_for_watcher() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             media_channel: media_receiver,
             notification_channel: sender,
@@ -432,7 +433,7 @@ async fn endpoint_watcher_receives_failed_when_port_rejected() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             media_channel: media_receiver,
             notification_channel: sender,
@@ -461,7 +462,7 @@ async fn second_watcher_rejected_on_same_app_when_both_any_stream_key() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             media_channel: media_receiver,
             notification_channel: sender,
@@ -484,7 +485,7 @@ async fn second_watcher_rejected_on_same_app_when_both_any_stream_key() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             media_channel: media_receiver,
             notification_channel: sender,
@@ -511,8 +512,8 @@ async fn second_watcher_rejected_on_same_app_and_same_exact_key() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             media_channel: media_receiver,
             notification_channel: sender,
         })
@@ -534,8 +535,8 @@ async fn second_watcher_rejected_on_same_app_and_same_exact_key() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             media_channel: media_receiver,
             notification_channel: sender,
         })
@@ -562,7 +563,7 @@ async fn second_watcher_rejected_on_same_app_when_first_request_is_for_any_key()
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             media_channel: media_receiver,
             notification_channel: sender,
@@ -585,8 +586,8 @@ async fn second_watcher_rejected_on_same_app_when_first_request_is_for_any_key()
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             media_channel: media_receiver,
             notification_channel: sender,
         })
@@ -612,8 +613,8 @@ async fn second_watcher_rejected_on_same_app_when_first_request_is_for_specific_
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             media_channel: media_receiver,
             notification_channel: sender,
         })
@@ -636,7 +637,7 @@ async fn second_watcher_rejected_on_same_app_when_first_request_is_for_specific_
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             media_channel: media_receiver,
             notification_channel: sender,
@@ -664,8 +665,8 @@ async fn second_watcher_accepted_on_same_app_with_different_exact_keys() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("abc".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("abc".to_string())),
             media_channel: media_receiver,
             notification_channel: sender,
         })
@@ -688,8 +689,8 @@ async fn second_watcher_accepted_on_same_app_with_different_exact_keys() {
             use_tls: false,
             requires_registrant_approval: false,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
-            rtmp_stream_key: StreamKeyRegistration::Exact("def".to_string()),
+            rtmp_app: Arc::new("app".to_string()),
+            rtmp_stream_key: StreamKeyRegistration::Exact(Arc::new("def".to_string())),
             media_channel: media_receiver,
             notification_channel: sender,
         })
@@ -716,7 +717,7 @@ async fn second_request_fails_if_tls_option_differs() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app".to_string(),
+            rtmp_app: Arc::new("app".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender,
         })
@@ -738,7 +739,7 @@ async fn second_request_fails_if_tls_option_differs() {
             requires_registrant_approval: false,
             stream_id: None,
             ip_restrictions: IpRestriction::None,
-            rtmp_app: "app2".to_string(),
+            rtmp_app: Arc::new("app2".to_string()),
             rtmp_stream_key: StreamKeyRegistration::Any,
             message_channel: sender2,
         })
@@ -766,7 +767,7 @@ async fn publisher_disconnected_if_connecting_to_wrong_app() {
 #[tokio::test]
 async fn publisher_disconnected_if_connecting_to_wrong_stream_key() {
     let mut context = TestContextBuilder::new()
-        .set_stream_key(StreamKeyRegistration::Exact("key".to_string()))
+        .set_stream_key(StreamKeyRegistration::Exact(Arc::new("key".to_string())))
         .into_publisher()
         .await;
 
@@ -787,7 +788,7 @@ async fn publisher_disconnected_if_connecting_to_wrong_stream_key() {
 #[tokio::test]
 async fn publisher_can_connect_on_registered_app_and_stream_key() {
     let mut context = TestContextBuilder::new()
-        .set_stream_key(StreamKeyRegistration::Exact("key".to_string()))
+        .set_stream_key(StreamKeyRegistration::Exact(Arc::new("key".to_string())))
         .into_publisher()
         .await;
 
@@ -812,14 +813,14 @@ async fn publisher_can_connect_on_registered_app_and_stream_key() {
             reactor_update_channel: _,
         } => {
             assert_eq!(
-                stream_key,
-                "key".to_string(),
+                stream_key.as_str(),
+                "key",
                 "Unexpected stream key in publisher connected message"
             );
 
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
         }
@@ -840,8 +841,8 @@ async fn publish_stopped_notification_raised_on_disconnection() {
     match response {
         RtmpEndpointPublisherMessage::PublishingStopped { connection_id } => {
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
         }
@@ -862,8 +863,8 @@ async fn publish_stopped_when_rtmp_client_stops_publishing() {
     match response {
         RtmpEndpointPublisherMessage::PublishingStopped { connection_id } => {
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
         }
@@ -894,8 +895,8 @@ async fn notification_raised_when_video_published() {
             composition_time_offset: _,
         } => {
             assert_eq!(
-                publisher.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                publisher.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
 
@@ -1095,8 +1096,8 @@ async fn notification_raised_when_metadata_published() {
             metadata: event_metadata,
         } => {
             assert_eq!(
-                publisher.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                publisher.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
 
@@ -1130,8 +1131,8 @@ async fn notification_raised_when_audio_published() {
             codec: _,
         } => {
             assert_eq!(
-                publisher.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                publisher.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
 
@@ -1273,7 +1274,7 @@ async fn stream_becoming_active_notification_when_watcher_connects() {
             stream_key,
             reactor_update_channel: _,
         } => {
-            assert_eq!(stream_key, "key".to_string());
+            assert_eq!(stream_key.as_str(), "key");
         }
 
         message => panic!("Unexpected publisher message received: {:?}", message),
@@ -1290,7 +1291,7 @@ async fn stream_becomes_inactive_when_only_watcher_stops_playback() {
     let response = test_utils::expect_mpsc_response(receiver).await;
     match response {
         RtmpEndpointWatcherNotification::StreamKeyBecameInactive { stream_key } => {
-            assert_eq!(stream_key, "key".to_string());
+            assert_eq!(stream_key.as_str(), "key");
         }
 
         message => panic!("Unexpected publisher message received: {:?}", message),
@@ -1307,7 +1308,7 @@ async fn stream_becomes_inactive_when_only_watcher_disconnects() {
     let response = test_utils::expect_mpsc_response(receiver).await;
     match response {
         RtmpEndpointWatcherNotification::StreamKeyBecameInactive { stream_key } => {
-            assert_eq!(stream_key, "key".to_string());
+            assert_eq!(stream_key.as_str(), "key");
         }
 
         message => panic!("Unexpected publisher message received: {:?}", message),
@@ -1327,7 +1328,7 @@ async fn watcher_receives_metadata() {
         .as_ref()
         .unwrap()
         .send(RtmpEndpointMediaMessage {
-            stream_key: "key".to_string(),
+            stream_key: Arc::new("key".to_string()),
             data: RtmpEndpointMediaData::NewStreamMetaData {
                 metadata: metadata.clone(),
             },
@@ -1369,7 +1370,7 @@ async fn watcher_receives_video_wrapped_in_flv_tag_denoting_non_keyframe() {
         .as_ref()
         .unwrap()
         .send(RtmpEndpointMediaMessage {
-            stream_key: "key".to_string(),
+            stream_key: Arc::new("key".to_string()),
             data: RtmpEndpointMediaData::NewVideoData {
                 codec: H264,
                 data: sent_data.clone(),
@@ -1416,7 +1417,7 @@ async fn watcher_receives_video_wrapped_in_flv_tag_denoting_keyframe() {
         .as_ref()
         .unwrap()
         .send(RtmpEndpointMediaMessage {
-            stream_key: "key".to_string(),
+            stream_key: Arc::new("key".to_string()),
             data: RtmpEndpointMediaData::NewVideoData {
                 codec: H264,
                 data: sent_data.clone(),
@@ -1463,7 +1464,7 @@ async fn watcher_does_not_receive_non_h264_video() {
         .as_ref()
         .unwrap()
         .send(RtmpEndpointMediaMessage {
-            stream_key: "key".to_string(),
+            stream_key: Arc::new("key".to_string()),
             data: RtmpEndpointMediaData::NewVideoData {
                 codec: Unknown,
                 data: sent_data.clone(),
@@ -1496,7 +1497,7 @@ async fn aac_audio_has_flv_headers_added_for_sequence_header() {
         .as_ref()
         .unwrap()
         .send(RtmpEndpointMediaMessage {
-            stream_key: "key".to_string(),
+            stream_key: Arc::new("key".to_string()),
             data: RtmpEndpointMediaData::NewAudioData {
                 codec: AudioCodec::Aac,
                 data: sent_data.clone(),
@@ -1536,7 +1537,7 @@ async fn aac_audio_has_flv_headers_added_for_non_sequence_header() {
         .as_ref()
         .unwrap()
         .send(RtmpEndpointMediaMessage {
-            stream_key: "key".to_string(),
+            stream_key: Arc::new("key".to_string()),
             data: RtmpEndpointMediaData::NewAudioData {
                 codec: AudioCodec::Aac,
                 data: sent_data.clone(),
@@ -1576,7 +1577,7 @@ async fn watcher_does_not_receives_unknown_audio_codec() {
         .as_ref()
         .unwrap()
         .send(RtmpEndpointMediaMessage {
-            stream_key: "key".to_string(),
+            stream_key: Arc::new("key".to_string()),
             data: RtmpEndpointMediaData::NewAudioData {
                 codec: AudioCodec::Unknown,
                 data: sent_data.clone(),
@@ -1620,10 +1621,10 @@ async fn consumer_accepts_publisher() {
             connection_id,
             response_channel,
         } => {
-            assert_eq!(stream_key, "key".to_string(), "Unexpected stream key");
+            assert_eq!(stream_key.as_str(), "key", "Unexpected stream key");
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
 
@@ -1647,11 +1648,11 @@ async fn consumer_accepts_publisher() {
             stream_key,
         } => {
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
-            assert_eq!(stream_key, "key".to_string(), "Unexpected stream key");
+            assert_eq!(stream_key.as_str(), "key", "Unexpected stream key");
             assert!(
                 reactor_update_channel.is_some(),
                 "Expected a reactor channel"
@@ -1688,10 +1689,10 @@ async fn consumer_rejectin_publisher_disconnects_client() {
             connection_id,
             response_channel,
         } => {
-            assert_eq!(stream_key, "key".to_string(), "Unexpected stream key");
+            assert_eq!(stream_key.as_str(), "key", "Unexpected stream key");
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
 
@@ -1732,10 +1733,10 @@ async fn consumer_accepts_watcher() {
             connection_id,
             response_channel,
         } => {
-            assert_eq!(stream_key, "key".to_string(), "Unexpected stream key");
+            assert_eq!(stream_key.as_str(), "key", "Unexpected stream key");
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
 
@@ -1756,7 +1757,7 @@ async fn consumer_accepts_watcher() {
             stream_key,
             reactor_update_channel,
         } => {
-            assert_eq!(stream_key, "key".to_string(), "Unexpected stream key");
+            assert_eq!(stream_key.as_str(), "key", "Unexpected stream key");
             assert!(
                 reactor_update_channel.is_some(),
                 "Expected reactor update channel"
@@ -1793,10 +1794,10 @@ async fn consumer_rejecting_watcher_disconnects_client() {
             connection_id,
             response_channel,
         } => {
-            assert_eq!(stream_key, "key".to_string(), "Unexpected stream key");
+            assert_eq!(stream_key.as_str(), "key", "Unexpected stream key");
             assert_eq!(
-                connection_id.0,
-                rtmp_client::CONNECTION_ID.to_string(),
+                connection_id.0.as_str(),
+                rtmp_client::CONNECTION_ID,
                 "Unexpected connection id"
             );
 

--- a/mmids-rtmp/src/rtmp_server/actor/tests/rtmp_client.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/rtmp_client.rs
@@ -11,6 +11,7 @@ use rml_rtmp::sessions::{
 };
 use rml_rtmp::time::RtmpTimestamp;
 use std::net::{SocketAddr, SocketAddrV4};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::time::timeout;
@@ -131,7 +132,7 @@ impl RtmpTestClient {
             panic!("Only one connection is supported at a time");
         }
 
-        let connection_id = ConnectionId(CONNECTION_ID.to_string());
+        let connection_id = ConnectionId(Arc::new(CONNECTION_ID.to_string()));
         let (incoming_sender, incoming_receiver) = unbounded_channel();
         let (outgoing_sender, mut outgoing_receiver) = unbounded_channel();
 

--- a/mmids-rtmp/src/rtmp_server/actor/tests/test_context.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/test_context.rs
@@ -5,6 +5,7 @@ use crate::rtmp_server::{
     StreamKeyRegistration,
 };
 use mmids_core::{test_utils, StreamId};
+use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 const RTMP_APP: &str = "app";
@@ -15,7 +16,7 @@ pub struct TestContextBuilder {
     requires_registrant_approval: Option<bool>,
     stream_id: Option<Option<StreamId>>,
     ip_restriction: Option<IpRestriction>,
-    rtmp_app: Option<String>,
+    rtmp_app: Option<Arc<String>>,
     rtmp_stream_key: Option<StreamKeyRegistration>,
 }
 
@@ -59,7 +60,9 @@ impl TestContextBuilder {
             requires_registrant_approval: self.requires_registrant_approval.unwrap_or(false),
             stream_id: self.stream_id.unwrap_or(None),
             ip_restrictions: self.ip_restriction.unwrap_or(IpRestriction::None),
-            rtmp_app: self.rtmp_app.unwrap_or_else(|| RTMP_APP.to_string()),
+            rtmp_app: self
+                .rtmp_app
+                .unwrap_or_else(|| Arc::new(RTMP_APP.to_string())),
             rtmp_stream_key: self.rtmp_stream_key.unwrap_or(StreamKeyRegistration::Any),
             message_channel: sender,
         };
@@ -75,7 +78,9 @@ impl TestContextBuilder {
             use_tls: self.use_tls.unwrap_or(false),
             requires_registrant_approval: self.requires_registrant_approval.unwrap_or(false),
             ip_restrictions: self.ip_restriction.unwrap_or(IpRestriction::None),
-            rtmp_app: self.rtmp_app.unwrap_or_else(|| RTMP_APP.to_string()),
+            rtmp_app: self
+                .rtmp_app
+                .unwrap_or_else(|| Arc::new(RTMP_APP.to_string())),
             rtmp_stream_key: self.rtmp_stream_key.unwrap_or(StreamKeyRegistration::Any),
             notification_channel: notification_sender,
             media_channel: media_receiver,

--- a/mmids-rtmp/src/rtmp_server/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/mod.rs
@@ -28,6 +28,7 @@ use mmids_core::StreamId;
 use rml_rtmp::sessions::StreamMetadata;
 use rml_rtmp::time::RtmpTimestamp;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
 
@@ -55,7 +56,7 @@ pub enum StreamKeyRegistration {
     Any,
 
     /// Only set up registration for the exact stream key
-    Exact(String),
+    Exact(Arc<String>),
 }
 
 /// Specifies if there are any IP address restrictions as part of an RTMP server registration
@@ -88,7 +89,7 @@ pub enum RtmpEndpointRequest {
         port: u16,
 
         /// Name of the RTMP application publishers will connect to
-        rtmp_app: String,
+        rtmp_app: Arc<String>,
 
         /// What stream key publishers should be using
         rtmp_stream_key: StreamKeyRegistration,
@@ -121,7 +122,7 @@ pub enum RtmpEndpointRequest {
         port: u16,
 
         /// Name of the RTMP application playback clients will connect to
-        rtmp_app: String,
+        rtmp_app: Arc<String>,
 
         /// Stream keys clients can receive video on
         rtmp_stream_key: StreamKeyRegistration,
@@ -153,7 +154,7 @@ pub enum RtmpEndpointRequest {
         port: u16,
 
         /// The RTMP application name that the registrant was listening on
-        rtmp_app: String,
+        rtmp_app: Arc<String>,
 
         /// The stream key the registrant had registered for
         rtmp_stream_key: StreamKeyRegistration,
@@ -187,7 +188,7 @@ pub enum RtmpEndpointPublisherMessage {
         connection_id: ConnectionId,
 
         /// The stream key that the connection is requesting to be a publisher to
-        stream_key: String,
+        stream_key: Arc<String>,
 
         /// Channel to send the approval or rejection response to
         response_channel: Sender<ValidationResponse>,
@@ -203,7 +204,7 @@ pub enum RtmpEndpointPublisherMessage {
 
         /// Actual stream key that this stream is coming in from.  Mostly used if the registrant
         /// specified that Any stream key would be allowed.
-        stream_key: String,
+        stream_key: Arc<String>,
 
         /// If provided, this is a channel which will receive workflow updates from a reactor
         /// tied to this publisher
@@ -261,7 +262,7 @@ pub enum RtmpEndpointWatcherNotification {
         connection_id: ConnectionId,
 
         /// The stream key that the connection is requesting to be a watcher of
-        stream_key: String,
+        stream_key: Arc<String>,
 
         /// Channel to send the approval or rejection response to
         response_channel: Sender<ValidationResponse>,
@@ -270,19 +271,19 @@ pub enum RtmpEndpointWatcherNotification {
     /// Notifies the registrant that at least one watcher is now watching on a particular
     /// stream key,
     StreamKeyBecameActive {
-        stream_key: String,
+        stream_key: Arc<String>,
         reactor_update_channel: Option<UnboundedReceiver<ReactorWorkflowUpdate>>,
     },
 
     /// Notifies the registrant that the last watcher has disconnected on the stream key, and
     /// there are no longer anyone watching
-    StreamKeyBecameInactive { stream_key: String },
+    StreamKeyBecameInactive { stream_key: Arc<String> },
 }
 
 /// Message watcher registrants send to announce new media data that should be sent to watchers
 #[derive(Debug)]
 pub struct RtmpEndpointMediaMessage {
-    pub stream_key: String,
+    pub stream_key: Arc<String>,
     pub data: RtmpEndpointMediaData,
 }
 

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
@@ -11,6 +11,7 @@ use mmids_core::{test_utils, StreamId, VideoTimestamp};
 use rml_rtmp::sessions::StreamMetadata;
 use rml_rtmp::time::RtmpTimestamp;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot::channel;
 
@@ -169,10 +170,10 @@ async fn requests_registration_for_publishers() {
             ..
         } => {
             assert_eq!(port, 1234, "Unexpected port");
-            assert_eq!(&rtmp_app, "some_app", "Unexpected rtmp app");
+            assert_eq!(rtmp_app.as_str(), "some_app", "Unexpected rtmp app");
             assert_eq!(
                 rtmp_stream_key,
-                StreamKeyRegistration::Exact("some_key".to_string()),
+                StreamKeyRegistration::Exact(Arc::new("some_key".to_string())),
                 "Unexpected stream key"
             );
         }
@@ -314,9 +315,9 @@ async fn stream_started_notification_raised_when_publisher_connects() {
 
     channel
         .send(RtmpEndpointPublisherMessage::NewPublisherConnected {
-            stream_id: StreamId("test".to_string()),
-            stream_key: "abc".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
+            stream_key: Arc::new("abc".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             reactor_update_channel: None,
         })
         .expect("Failed to send publisher connected message");
@@ -330,11 +331,11 @@ async fn stream_started_notification_raised_when_publisher_connects() {
     );
 
     let media = &context.step_context.media_outputs[0];
-    assert_eq!(&media.stream_id.0, "test", "Unexpected stream id");
+    assert_eq!(media.stream_id.0.as_str(), "test", "Unexpected stream id");
 
     match &media.content {
         MediaNotificationContent::NewIncomingStream { stream_name } => {
-            assert_eq!(stream_name, "abc", "Unexpected stream name");
+            assert_eq!(stream_name.as_str(), "abc", "Unexpected stream name");
         }
 
         content => panic!("Unexpected media content: {:?}", content),
@@ -349,9 +350,9 @@ async fn stream_disconnected_notification_raised_when_publisher_disconnects() {
 
     channel
         .send(RtmpEndpointPublisherMessage::NewPublisherConnected {
-            stream_id: StreamId("test".to_string()),
-            stream_key: "abc".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
+            stream_key: Arc::new("abc".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             reactor_update_channel: None,
         })
         .expect("Failed to send publisher connected message");
@@ -361,7 +362,7 @@ async fn stream_disconnected_notification_raised_when_publisher_disconnects() {
 
     channel
         .send(RtmpEndpointPublisherMessage::PublishingStopped {
-            connection_id: ConnectionId("connection".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
         })
         .expect("Failed to send disconnected message");
 
@@ -374,7 +375,7 @@ async fn stream_disconnected_notification_raised_when_publisher_disconnects() {
     );
 
     let media = &context.step_context.media_outputs[0];
-    assert_eq!(&media.stream_id.0, "test", "Unexpected stream id");
+    assert_eq!(media.stream_id.0.as_str(), "test", "Unexpected stream id");
 
     match &media.content {
         MediaNotificationContent::StreamDisconnected => (),
@@ -390,9 +391,9 @@ async fn metadata_notification_raised_when_publisher_sends_one() {
 
     channel
         .send(RtmpEndpointPublisherMessage::NewPublisherConnected {
-            stream_id: StreamId("test".to_string()),
-            stream_key: "abc".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
+            stream_key: Arc::new("abc".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             reactor_update_channel: None,
         })
         .expect("Failed to send publisher connected message");
@@ -405,7 +406,7 @@ async fn metadata_notification_raised_when_publisher_sends_one() {
     channel
         .send(RtmpEndpointPublisherMessage::StreamMetadataChanged {
             metadata,
-            publisher: ConnectionId("connection".to_string()),
+            publisher: ConnectionId(Arc::new("connection".to_string())),
         })
         .expect("Failed to send metadata message");
 
@@ -418,7 +419,7 @@ async fn metadata_notification_raised_when_publisher_sends_one() {
     );
 
     let media = &context.step_context.media_outputs[0];
-    assert_eq!(&media.stream_id.0, "test", "Unexpected stream id");
+    assert_eq!(media.stream_id.0.as_str(), "test", "Unexpected stream id");
 
     match &media.content {
         MediaNotificationContent::Metadata { data } => {
@@ -441,9 +442,9 @@ async fn video_notification_received_when_publisher_sends_video() {
 
     channel
         .send(RtmpEndpointPublisherMessage::NewPublisherConnected {
-            stream_id: StreamId("test".to_string()),
-            stream_key: "abc".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
+            stream_key: Arc::new("abc".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             reactor_update_channel: None,
         })
         .expect("Failed to send publisher connected message");
@@ -452,7 +453,7 @@ async fn video_notification_received_when_publisher_sends_video() {
 
     channel
         .send(RtmpEndpointPublisherMessage::NewVideoData {
-            publisher: ConnectionId("connection".to_string()),
+            publisher: ConnectionId(Arc::new("connection".to_string())),
             data: Bytes::from(vec![1, 2, 3]),
             codec: VideoCodec::H264,
             timestamp: RtmpTimestamp::new(5),
@@ -471,7 +472,7 @@ async fn video_notification_received_when_publisher_sends_video() {
     );
 
     let media = &context.step_context.media_outputs[0];
-    assert_eq!(&media.stream_id.0, "test", "Unexpected stream id");
+    assert_eq!(media.stream_id.0.as_str(), "test", "Unexpected stream id");
 
     match &media.content {
         MediaNotificationContent::Video {
@@ -501,9 +502,9 @@ async fn audio_notification_received_when_publisher_sends_audio() {
 
     channel
         .send(RtmpEndpointPublisherMessage::NewPublisherConnected {
-            stream_id: StreamId("test".to_string()),
-            stream_key: "abc".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
+            stream_key: Arc::new("abc".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             reactor_update_channel: None,
         })
         .expect("Failed to send publisher connected message");
@@ -512,7 +513,7 @@ async fn audio_notification_received_when_publisher_sends_audio() {
 
     channel
         .send(RtmpEndpointPublisherMessage::NewAudioData {
-            publisher: ConnectionId("connection".to_string()),
+            publisher: ConnectionId(Arc::new("connection".to_string())),
             data: Bytes::from(vec![1, 2, 3]),
             codec: AudioCodec::Aac,
             timestamp: RtmpTimestamp::new(5),
@@ -529,7 +530,7 @@ async fn audio_notification_received_when_publisher_sends_audio() {
     );
 
     let media = &context.step_context.media_outputs[0];
-    assert_eq!(&media.stream_id.0, "test", "Unexpected stream id");
+    assert_eq!(media.stream_id.0.as_str(), "test", "Unexpected stream id");
 
     match &media.content {
         MediaNotificationContent::Audio {
@@ -556,9 +557,9 @@ fn stream_started_notification_passed_as_input_does_not_get_passed_as_output() {
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: MediaNotificationContent::NewIncomingStream {
-                stream_name: "name".to_string(),
+                stream_name: Arc::new("name".to_string()),
             },
         });
 }
@@ -571,7 +572,7 @@ fn stream_disconnected_notification_passed_as_input_does_not_get_passed_as_outpu
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: StreamDisconnected,
         });
 }
@@ -584,7 +585,7 @@ fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: MediaNotificationContent::Metadata {
                 data: HashMap::new(),
             },
@@ -599,7 +600,7 @@ fn video_notification_passed_as_input_does_not_get_passed_as_output() {
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: MediaNotificationContent::Video {
                 data: Bytes::from(vec![1, 2]),
                 codec: VideoCodec::H264,
@@ -618,7 +619,7 @@ fn audio_notification_passed_as_input_does_not_get_passed_as_output() {
     context
         .step_context
         .assert_media_not_passed_through(MediaNotification {
-            stream_id: StreamId("test".to_string()),
+            stream_id: StreamId(Arc::new("test".to_string())),
             content: MediaNotificationContent::Audio {
                 data: Bytes::from(vec![1, 2]),
                 codec: AudioCodec::Aac,
@@ -657,8 +658,8 @@ async fn reactor_queried_for_stream_key_when_approval_required() {
     let (sender, _receiver) = channel();
     publish_channel
         .send(RtmpEndpointPublisherMessage::PublisherRequiringApproval {
-            stream_key: "ab123".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_key: Arc::new("ab123".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             response_channel: sender,
         })
         .expect("Failed to send publisher message");
@@ -672,8 +673,8 @@ async fn reactor_queried_for_stream_key_when_approval_required() {
             stream_name,
             ..
         } => {
-            assert_eq!(&reactor_name, "abc", "Unexpected reactor name");
-            assert_eq!(&stream_name, "ab123", "Unexpected stream name");
+            assert_eq!(reactor_name.as_str(), "abc", "Unexpected reactor name");
+            assert_eq!(stream_name.as_str(), "ab123", "Unexpected stream name");
         }
 
         request => panic!("Unexpected request received: {:?}", request),
@@ -689,8 +690,8 @@ async fn rejection_sent_when_reactor_says_stream_is_not_valid() {
     let (sender, receiver) = channel();
     publish_channel
         .send(RtmpEndpointPublisherMessage::PublisherRequiringApproval {
-            stream_key: "ab123".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_key: Arc::new("ab123".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             response_channel: sender,
         })
         .expect("Failed to send publisher message");
@@ -723,8 +724,8 @@ async fn approval_sent_when_reactor_says_stream_is_valid() {
     let (sender, receiver) = channel();
     publish_channel
         .send(RtmpEndpointPublisherMessage::PublisherRequiringApproval {
-            stream_key: "ab123".to_string(),
-            connection_id: ConnectionId("connection".to_string()),
+            stream_key: Arc::new("ab123".to_string()),
+            connection_id: ConnectionId(Arc::new("connection".to_string())),
             response_channel: sender,
         })
         .expect("Failed to send publisher message");

--- a/validators/rtmp-server/src/main.rs
+++ b/validators/rtmp-server/src/main.rs
@@ -8,6 +8,7 @@ use mmids_rtmp::rtmp_server::{
 };
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::mpsc::unbounded_channel;
 
 #[tokio::main()]
@@ -21,7 +22,7 @@ pub async fn main() {
     let (rtmp_response_sender, mut publish_notification_receiver) = unbounded_channel();
     let _ = rtmp_server_sender.send(RtmpEndpointRequest::ListenForPublishers {
         port: 1935,
-        rtmp_app: "live".to_string(),
+        rtmp_app: Arc::new("live".to_string()),
         rtmp_stream_key: StreamKeyRegistration::Any,
         message_channel: rtmp_response_sender,
         stream_id: None,
@@ -52,7 +53,7 @@ pub async fn main() {
 
     let _ = rtmp_server_sender.send(RtmpEndpointRequest::ListenForWatchers {
         port: 1935,
-        rtmp_app: "live".to_string(),
+        rtmp_app: Arc::new("live".to_string()),
         rtmp_stream_key: StreamKeyRegistration::Any,
         media_channel: media_receiver,
         notification_channel: notification_sender,


### PR DESCRIPTION
There are several types of strings that are central to mmids: Stream Ids, connection ids, stream names, and various RTMP specific strings.  Many of these strings are used on every media packet that flows through mmids, and is therefore cloned many times for each media packet.  This causes a lot of heap allocations even though each individual allocated string is never mutated once set.

This change makes these into `Arc<String>` types, so that they can be cloned cheaply and re-used all throughout the media flow with minimal heap allocations.