### PR TITLE
Remove Audio/Video media notification content variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,24 +4,24 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "array-init"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb6d71005dc22a708c7496eee5c8dc0300ee47355de6256c3b35b12b5fef596"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "async-recursion"
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -51,7 +51,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -94,15 +94,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-expr"
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -599,7 +599,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.4",
  "tracing",
 ]
 
@@ -620,6 +620,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -700,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -719,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "lazy_static"
@@ -731,9 +740,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lock_api"
@@ -944,19 +953,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -966,9 +975,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -998,9 +1007,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1036,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1049,15 +1058,15 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pest"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a528564cc62c19a7acac4d81e01f39e53e25e17b934878f4c6d25cc2836e62f8"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1065,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fd9bc6500181952d34bd0b2b0163a54d794227b498be0b7afa7698d0a7b18f"
+checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1075,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2610d5ac5156217b4ff8e46ddcef7cdf44b273da2ac5bca2ecbfa86a330e7c4"
+checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1088,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824749bf7e21dd66b36fbe26b3f45c713879cccd4a009a917ab8e045ca8246fe"
+checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
@@ -1184,18 +1193,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1317,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schannel"
@@ -1362,18 +1371,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1382,9 +1391,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -1399,7 +1408,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1466,9 +1475,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1513,18 +1522,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1589,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1624,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1638,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -1752,9 +1761,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -1764,9 +1773,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "downcast-rs",
  "futures",
  "hyper",
+ "lazy_static",
  "native-tls",
  "pest",
  "pest_derive",

--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -22,6 +22,7 @@ cidr-utils = "0.5.5"
 downcast-rs = "1.2.0"
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
+lazy_static = "1.4"
 native-tls = "0.2"
 pest = "2.1"
 pest_derive = "2.1"

--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://kalldrexx.github.io/mmids/"
 test-utils = []
 
 [dependencies]
-anyhow = "1.0.54"
+anyhow = "1.0"
 async-recursion = "0.3.2"
 async-trait = "0.1.51"
 byteorder = "1.4.3"

--- a/mmids-core/src/codecs.rs
+++ b/mmids-core/src/codecs.rs
@@ -1,8 +1,10 @@
-/// Video codecs that can be identified
-#[derive(Debug, Clone, Eq, PartialEq, Copy)]
-pub enum VideoCodec {
-    Unknown,
-    H264,
+//! Standard codec identifiers
+use std::sync::Arc;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref VIDEO_CODEC_H264_AVC: Arc<String> = Arc::new("h264-avc".to_string());
+    pub static ref AUDIO_CODEC_AAC_RAW: Arc<String> = Arc::new("aac-raw".to_string());
 }
 
 /// Audio codecs that can be identified
@@ -10,4 +12,11 @@ pub enum VideoCodec {
 pub enum AudioCodec {
     Unknown,
     Aac,
+}
+
+/// Video codecs that can be identified
+#[derive(Debug, Clone, Eq, PartialEq, Copy)]
+pub enum VideoCodec {
+    Unknown,
+    H264,
 }

--- a/mmids-core/src/codecs.rs
+++ b/mmids-core/src/codecs.rs
@@ -1,6 +1,6 @@
 //! Standard codec identifiers
-use std::sync::Arc;
 use lazy_static::lazy_static;
+use std::sync::Arc;
 
 lazy_static! {
     pub static ref VIDEO_CODEC_H264_AVC: Arc<String> = Arc::new("h264-avc".to_string());

--- a/mmids-core/src/codecs.rs
+++ b/mmids-core/src/codecs.rs
@@ -6,17 +6,3 @@ lazy_static! {
     pub static ref VIDEO_CODEC_H264_AVC: Arc<String> = Arc::new("h264-avc".to_string());
     pub static ref AUDIO_CODEC_AAC_RAW: Arc<String> = Arc::new("aac-raw".to_string());
 }
-
-/// Audio codecs that can be identified
-#[derive(Debug, Clone, Eq, PartialEq, Copy)]
-pub enum AudioCodec {
-    Unknown,
-    Aac,
-}
-
-/// Video codecs that can be identified
-#[derive(Debug, Clone, Eq, PartialEq, Copy)]
-pub enum VideoCodec {
-    Unknown,
-    H264,
-}

--- a/mmids-core/src/workflows/metadata/common_metadata.rs
+++ b/mmids-core/src/workflows/metadata/common_metadata.rs
@@ -1,0 +1,15 @@
+//! Common types of media payload metadata that may be used
+
+use crate::workflows::metadata::{MetadataKey, MetadataKeyMap, MetadataValueType};
+
+/// Returns the metadata key for a metadata entry describing if a media payload is a video
+/// key frame.
+pub fn get_is_keyframe_metadata_key(metadata_map: &mut MetadataKeyMap) -> MetadataKey {
+    metadata_map.register("is_keyframe", MetadataValueType::Bool)
+}
+
+/// Returns the metadata key for a metadata entry describing the number of milliseconds the
+/// pts (presentation timestamp) value is offset from the dts (decoding timestamp).
+pub fn get_pts_offset_metadata_key(metadata_map: &mut MetadataKeyMap) -> MetadataKey {
+    metadata_map.register("pts_offset", MetadataValueType::I32)
+}

--- a/mmids-core/src/workflows/metadata/mod.rs
+++ b/mmids-core/src/workflows/metadata/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains functionality for storing and retrieving metadata about individual
 //! media payloads.
 
+pub mod common_metadata;
 mod keys;
 mod klv;
 

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -11,8 +11,7 @@ pub mod steps;
 
 pub use runner::{start_workflow, WorkflowRequest, WorkflowRequestOperation, WorkflowStatus};
 
-use crate::codecs::VideoCodec;
-use crate::{StreamId, VideoTimestamp};
+use crate::StreamId;
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -54,15 +53,6 @@ pub enum MediaNotificationContent {
     /// information they are tracking about this stream, as no new media will arrive without
     /// a new `NewIncomingStream` announcement.
     StreamDisconnected,
-
-    /// Video content
-    Video {
-        codec: VideoCodec,
-        is_sequence_header: bool,
-        is_keyframe: bool,
-        data: Bytes,
-        timestamp: VideoTimestamp,
-    },
 
     /// New stream metadata
     Metadata { data: HashMap<String, String> },

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -11,7 +11,7 @@ pub mod steps;
 
 pub use runner::{start_workflow, WorkflowRequest, WorkflowRequestOperation, WorkflowStatus};
 
-use crate::codecs::{VideoCodec};
+use crate::codecs::VideoCodec;
 use crate::{StreamId, VideoTimestamp};
 use bytes::Bytes;
 use std::collections::HashMap;

--- a/mmids-core/src/workflows/mod.rs
+++ b/mmids-core/src/workflows/mod.rs
@@ -11,7 +11,7 @@ pub mod steps;
 
 pub use runner::{start_workflow, WorkflowRequest, WorkflowRequestOperation, WorkflowStatus};
 
-use crate::codecs::{AudioCodec, VideoCodec};
+use crate::codecs::{VideoCodec};
 use crate::{StreamId, VideoTimestamp};
 use bytes::Bytes;
 use std::collections::HashMap;
@@ -62,14 +62,6 @@ pub enum MediaNotificationContent {
         is_keyframe: bool,
         data: Bytes,
         timestamp: VideoTimestamp,
-    },
-
-    /// Audio content
-    Audio {
-        codec: AudioCodec,
-        is_sequence_header: bool,
-        data: Bytes,
-        timestamp: Duration,
     },
 
     /// New stream metadata

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -633,7 +633,10 @@ impl Actor {
                 self.cached_inbound_media.remove(&media.stream_id);
             }
 
-            MediaNotificationContent::MediaPayload { is_required_for_decoding: true, ..} => {
+            MediaNotificationContent::MediaPayload {
+                is_required_for_decoding: true,
+                ..
+            } => {
                 if let Some(collection) = self.cached_inbound_media.get_mut(&media.stream_id) {
                     collection.push(media.clone());
                 }

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -595,7 +595,6 @@ impl Actor {
             match &media.content {
                 MediaNotificationContent::Metadata { .. } => (),
                 MediaNotificationContent::MediaPayload { .. } => (),
-                MediaNotificationContent::Video { .. } => (),
                 MediaNotificationContent::NewIncomingStream { .. } => {
                     if !self.active_streams.contains_key(&media.stream_id) {
                         // Since this is the first time we've gotten a new incoming stream
@@ -679,8 +678,6 @@ impl Actor {
                         Operation::Ignore
                     }
                 }
-
-                MediaNotificationContent::Video { .. } => Operation::Ignore,
             };
 
             match operation {

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -595,7 +595,6 @@ impl Actor {
             match &media.content {
                 MediaNotificationContent::Metadata { .. } => (),
                 MediaNotificationContent::MediaPayload { .. } => (),
-                MediaNotificationContent::Audio { .. } => (),
                 MediaNotificationContent::Video { .. } => (),
                 MediaNotificationContent::NewIncomingStream { .. } => {
                     if !self.active_streams.contains_key(&media.stream_id) {
@@ -678,7 +677,6 @@ impl Actor {
                     }
                 }
 
-                MediaNotificationContent::Audio { .. } => Operation::Ignore,
                 MediaNotificationContent::Video { .. } => Operation::Ignore,
             };
 

--- a/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
@@ -285,7 +285,10 @@ impl WorkflowForwarderStep {
                 // other data will come down as metadata that we don't want to permanently store.
             }
 
-            MediaNotificationContent::MediaPayload { is_required_for_decoding: true, .. } => {
+            MediaNotificationContent::MediaPayload {
+                is_required_for_decoding: true,
+                ..
+            } => {
                 if let Some(stream) = self.active_streams.get_mut(&media.stream_id) {
                     stream.required_media.push(media.clone());
                 }

--- a/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
@@ -285,19 +285,7 @@ impl WorkflowForwarderStep {
                 // other data will come down as metadata that we don't want to permanently store.
             }
 
-            MediaNotificationContent::Video {
-                is_sequence_header: true,
-                ..
-            } => {
-                if let Some(stream) = self.active_streams.get_mut(&media.stream_id) {
-                    stream.required_media.push(media.clone());
-                }
-            }
-
-            MediaNotificationContent::Audio {
-                is_sequence_header: true,
-                ..
-            } => {
+            MediaNotificationContent::MediaPayload { is_required_for_decoding: true, .. } => {
                 if let Some(stream) = self.active_streams.get_mut(&media.stream_id) {
                     stream.required_media.push(media.clone());
                 }

--- a/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
@@ -7,6 +7,7 @@ use crate::test_utils;
 use anyhow::{anyhow, Result};
 use bytes::{Bytes, BytesMut};
 use std::time::Duration;
+use crate::workflows::MediaType;
 use crate::workflows::metadata::MediaPayloadMetadataCollection;
 
 struct TestContext {
@@ -275,7 +276,8 @@ async fn media_passed_as_output_immediately() {
 
     let expected_content = MediaNotificationContent::MediaPayload {
         data: Bytes::from(vec![1, 2, 3]),
-        codec: Arc::new("test".to_string()),
+        payload_type: Arc::new("test".to_string()),
+        media_type: MediaType::Audio,
         is_required_for_decoding: true,
         timestamp: Duration::from_millis(10),
         metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut BytesMut::new()),

--- a/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
@@ -1,12 +1,13 @@
+use std::iter;
+use std::sync::Arc;
 use super::*;
-use crate::codecs::{AudioCodec, VideoCodec};
 use crate::workflows::definitions::WorkflowStepType;
 use crate::workflows::steps::StepTestContext;
-use crate::{test_utils, VideoTimestamp};
+use crate::test_utils;
 use anyhow::{anyhow, Result};
-use bytes::Bytes;
-use std::sync::Arc;
+use bytes::{Bytes, BytesMut};
 use std::time::Duration;
+use crate::workflows::metadata::MediaPayloadMetadataCollection;
 
 struct TestContext {
     reactor_manager: UnboundedReceiver<ReactorManagerRequest>,
@@ -269,21 +270,20 @@ async fn stream_disconnected_media_passed_as_output_immediately() {
 }
 
 #[tokio::test]
-async fn video_media_passed_as_output_immediately() {
+async fn media_passed_as_output_immediately() {
     let mut context = TestContext::new(Some("test"), None).await.unwrap();
 
+    let expected_content = MediaNotificationContent::MediaPayload {
+        data: Bytes::from(vec![1, 2, 3]),
+        codec: Arc::new("test".to_string()),
+        is_required_for_decoding: true,
+        timestamp: Duration::from_millis(10),
+        metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut BytesMut::new()),
+    };
+
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::Video {
-            data: Bytes::from(vec![1, 2, 3]),
-            codec: VideoCodec::H264,
-            timestamp: VideoTimestamp::from_durations(
-                Duration::from_millis(5),
-                Duration::from_millis(15),
-            ),
-            is_keyframe: true,
-            is_sequence_header: true,
-        },
+        stream_id: StreamId("abc".to_string()),
+        content: expected_content.clone(),
     });
 
     assert_eq!(
@@ -293,66 +293,8 @@ async fn video_media_passed_as_output_immediately() {
     );
 
     let media = &context.step_context.media_outputs[0];
-    assert_eq!(media.stream_id.0.as_str(), "abc", "Unexpected stream id");
-
-    match &media.content {
-        MediaNotificationContent::Video {
-            data,
-            codec,
-            timestamp,
-            is_keyframe,
-            is_sequence_header,
-        } => {
-            assert_eq!(data, &vec![1, 2, 3], "Unexpected bytes");
-            assert_eq!(codec, &VideoCodec::H264, "Unexpected codec");
-            assert_eq!(timestamp.dts(), Duration::from_millis(5), "Unexpected dts");
-            assert_eq!(timestamp.pts_offset(), 10, "Unexpected pts offset");
-            assert!(is_keyframe, "Expected is_keyframe to be true");
-            assert!(is_sequence_header, "Expected is_sequence_header to be true");
-        }
-
-        content => panic!("Unexpected media content: {:?}", content),
-    }
-}
-
-#[tokio::test]
-async fn audio_media_passed_as_output_immediately() {
-    let mut context = TestContext::new(Some("test"), None).await.unwrap();
-
-    context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::Audio {
-            data: Bytes::from(vec![1, 2, 3]),
-            codec: AudioCodec::Aac,
-            timestamp: Duration::from_millis(5),
-            is_sequence_header: true,
-        },
-    });
-
-    assert_eq!(
-        context.step_context.media_outputs.len(),
-        1,
-        "Unexpected number of media outputs"
-    );
-
-    let media = &context.step_context.media_outputs[0];
-    assert_eq!(media.stream_id.0.as_str(), "abc", "Unexpected stream id");
-
-    match &media.content {
-        MediaNotificationContent::Audio {
-            data,
-            codec,
-            timestamp,
-            is_sequence_header,
-        } => {
-            assert_eq!(data, &vec![1, 2, 3], "Unexpected bytes");
-            assert_eq!(codec, &AudioCodec::Aac, "Unexpected codec");
-            assert_eq!(timestamp, &Duration::from_millis(5), "Unexpected timestamp");
-            assert!(is_sequence_header, "Expected is_sequence_header to be true");
-        }
-
-        content => panic!("Unexpected media content: {:?}", content),
-    }
+    assert_eq!(media.stream_id.0, "abc", "Unexpected stream id");
+    assert_eq!(media.content, expected_content, "Unexpected media content");
 }
 
 #[tokio::test]
@@ -388,7 +330,7 @@ async fn metadata_media_passed_as_output_immediately() {
 }
 
 #[tokio::test]
-async fn video_sequence_headers_sent_to_workflow_when_received_before_workflow_starts() {
+async fn required_media_payload_sent_to_workflow_when_received_before_workflow_starts() {
     let mut context = TestContext::new(Some("test"), None).await.unwrap();
     context.step_context.execute_with_media(MediaNotification {
         stream_id: StreamId(Arc::new("abc".to_string())),
@@ -397,18 +339,17 @@ async fn video_sequence_headers_sent_to_workflow_when_received_before_workflow_s
         },
     });
 
+    let expected_content = MediaNotificationContent::MediaPayload {
+        data: Bytes::from(vec![1, 2, 3]),
+        codec: Arc::new("test".to_string()),
+        is_required_for_decoding: true,
+        timestamp: Duration::from_millis(10),
+        metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut BytesMut::new()),
+    };
+
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::Video {
-            data: Bytes::from(vec![1, 2, 3]),
-            codec: VideoCodec::H264,
-            timestamp: VideoTimestamp::from_durations(
-                Duration::from_millis(5),
-                Duration::from_millis(15),
-            ),
-            is_keyframe: true,
-            is_sequence_header: true,
-        },
+        stream_id: StreamId("abc".to_string()),
+        content: expected_content.clone(),
     });
 
     test_utils::expect_mpsc_timeout(&mut context.workflow_receiver).await;
@@ -426,17 +367,16 @@ async fn video_sequence_headers_sent_to_workflow_when_received_before_workflow_s
 
     let response = test_utils::expect_mpsc_response(&mut context.workflow_receiver).await;
     match response.operation {
-        WorkflowRequestOperation::MediaNotification { media } => match media.content {
-            MediaNotificationContent::Video { .. } => (),
-            content => panic!("Unexpected media content: {:?}", content),
-        },
+        WorkflowRequestOperation::MediaNotification { media } => {
+            assert_eq!(media.content, expected_content, "Unexpected media content");
+        }
 
         operation => panic!("Unexpected workflow operation: {:?}", operation),
     }
 }
 
 #[tokio::test]
-async fn non_video_sequence_headers_not_sent_to_workflow_when_received_before_workflow_starts() {
+async fn non_required_payload_not_sent_to_workflow_when_received_before_workflow_starts() {
     let mut context = TestContext::new(Some("test"), None).await.unwrap();
     context.step_context.execute_with_media(MediaNotification {
         stream_id: StreamId(Arc::new("abc".to_string())),
@@ -445,98 +385,17 @@ async fn non_video_sequence_headers_not_sent_to_workflow_when_received_before_wo
         },
     });
 
-    context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::Video {
-            data: Bytes::from(vec![1, 2, 3]),
-            codec: VideoCodec::H264,
-            timestamp: VideoTimestamp::from_durations(
-                Duration::from_millis(5),
-                Duration::from_millis(15),
-            ),
-            is_keyframe: true,
-            is_sequence_header: false,
-        },
-    });
-
-    test_utils::expect_mpsc_timeout(&mut context.workflow_receiver).await;
-    context.send_workflow_started_event("test", None).await;
-
-    let response = test_utils::expect_mpsc_response(&mut context.workflow_receiver).await;
-    match response.operation {
-        WorkflowRequestOperation::MediaNotification { media } => match media.content {
-            MediaNotificationContent::NewIncomingStream { .. } => (),
-            content => panic!("Unexpected media content: {:?}", content),
-        },
-
-        operation => panic!("Unexpected workflow operation: {:?}", operation),
-    }
-
-    test_utils::expect_mpsc_timeout(&mut context.workflow_receiver).await;
-}
-
-#[tokio::test]
-async fn audio_sequence_headers_sent_to_workflow_when_received_before_workflow_starts() {
-    let mut context = TestContext::new(Some("test"), None).await.unwrap();
-    context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::NewIncomingStream {
-            stream_name: Arc::new("def".to_string()),
-        },
-    });
+    let expected_content = MediaNotificationContent::MediaPayload {
+        data: Bytes::from(vec![1, 2, 3]),
+        codec: Arc::new("test".to_string()),
+        is_required_for_decoding: false,
+        timestamp: Duration::from_millis(10),
+        metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut BytesMut::new()),
+    };
 
     context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::Audio {
-            data: Bytes::from(vec![1, 2, 3]),
-            codec: AudioCodec::Aac,
-            timestamp: Duration::from_millis(5),
-            is_sequence_header: true,
-        },
-    });
-
-    test_utils::expect_mpsc_timeout(&mut context.workflow_receiver).await;
-    context.send_workflow_started_event("test", None).await;
-
-    let response = test_utils::expect_mpsc_response(&mut context.workflow_receiver).await;
-    match response.operation {
-        WorkflowRequestOperation::MediaNotification { media } => match media.content {
-            MediaNotificationContent::NewIncomingStream { .. } => (),
-            content => panic!("Unexpected media content: {:?}", content),
-        },
-
-        operation => panic!("Unexpected workflow operation: {:?}", operation),
-    }
-
-    let response = test_utils::expect_mpsc_response(&mut context.workflow_receiver).await;
-    match response.operation {
-        WorkflowRequestOperation::MediaNotification { media } => match media.content {
-            MediaNotificationContent::Audio { .. } => (),
-            content => panic!("Unexpected media content: {:?}", content),
-        },
-
-        operation => panic!("Unexpected workflow operation: {:?}", operation),
-    }
-}
-
-#[tokio::test]
-async fn non_audio_sequence_headers_not_sent_to_workflow_when_received_before_workflow_starts() {
-    let mut context = TestContext::new(Some("test"), None).await.unwrap();
-    context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::NewIncomingStream {
-            stream_name: Arc::new("def".to_string()),
-        },
-    });
-
-    context.step_context.execute_with_media(MediaNotification {
-        stream_id: StreamId(Arc::new("abc".to_string())),
-        content: MediaNotificationContent::Audio {
-            data: Bytes::from(vec![1, 2, 3]),
-            codec: AudioCodec::Aac,
-            timestamp: Duration::from_millis(5),
-            is_sequence_header: false,
-        },
+        stream_id: StreamId("abc".to_string()),
+        content: expected_content.clone(),
     });
 
     test_utils::expect_mpsc_timeout(&mut context.workflow_receiver).await;

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_hls/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_hls/mod.rs
@@ -9,6 +9,7 @@ use crate::endpoint::{
 use crate::workflow_steps::ffmpeg_handler::{FfmpegHandlerGenerator, FfmpegParameterGenerator};
 use futures::FutureExt;
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
+use mmids_core::workflows::metadata::MetadataKey;
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
@@ -20,7 +21,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
-use mmids_core::workflows::metadata::MetadataKey;
 
 const PATH: &str = "path";
 const SEGMENT_DURATION: &str = "duration";

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_hls/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_hls/mod.rs
@@ -40,8 +40,6 @@ struct FfmpegHlsStep {
     status: StepStatus,
     stream_reader: ExternalStreamReader,
     path: String,
-    is_keyframe_metadata_key: MetadataKey,
-    pts_offset_metadata_key: MetadataKey,
 }
 
 enum FutureResult {
@@ -151,8 +149,6 @@ impl StepGenerator for FfmpegHlsStepGenerator {
             status: StepStatus::Created,
             stream_reader: reader,
             path: path.clone(),
-            is_keyframe_metadata_key: self.is_keyframe_metadata_key,
-            pts_offset_metadata_key: self.pts_offset_metadata_key,
         };
 
         futures.push(notify_when_ffmpeg_endpoint_is_gone(self.ffmpeg_endpoint.clone()).boxed());

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
@@ -11,9 +11,9 @@ use crate::endpoint::{
 };
 use bytes::BytesMut;
 use futures::FutureExt;
-use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
-use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
+use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue};
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
@@ -40,6 +40,8 @@ pub const STREAM_NAME: &str = "stream_name";
 pub struct FfmpegPullStepGenerator {
     rtmp_endpoint: UnboundedSender<RtmpEndpointRequest>,
     ffmpeg_endpoint: UnboundedSender<FfmpegEndpointRequest>,
+    is_keyframe_metadata_key: MetadataKey,
+    pts_offset_metadata_key: MetadataKey,
 }
 
 struct FfmpegPullStep {
@@ -53,6 +55,8 @@ struct FfmpegPullStep {
     ffmpeg_id: Option<Uuid>,
     active_stream_id: Option<StreamId>,
     metadata_buffer: BytesMut,
+    is_keyframe_metadata_key: MetadataKey,
+    pts_offset_metadata_key: MetadataKey,
 }
 
 enum FutureResult {
@@ -83,10 +87,14 @@ impl FfmpegPullStepGenerator {
     pub fn new(
         rtmp_endpoint: UnboundedSender<RtmpEndpointRequest>,
         ffmpeg_endpoint: UnboundedSender<FfmpegEndpointRequest>,
+        is_keyframe_metadata_key: MetadataKey,
+        pts_offset_metadata_key: MetadataKey,
     ) -> Self {
         FfmpegPullStepGenerator {
             rtmp_endpoint,
             ffmpeg_endpoint,
+            is_keyframe_metadata_key,
+            pts_offset_metadata_key,
         }
     }
 }
@@ -114,6 +122,8 @@ impl StepGenerator for FfmpegPullStepGenerator {
             ffmpeg_id: None,
             active_stream_id: None,
             metadata_buffer: BytesMut::new(),
+            is_keyframe_metadata_key: self.is_keyframe_metadata_key,
+            pts_offset_metadata_key: self.pts_offset_metadata_key,
         };
 
         let (sender, receiver) = unbounded_channel();
@@ -294,20 +304,34 @@ impl FfmpegPullStep {
                 is_keyframe,
                 is_sequence_header,
                 timestamp,
-                codec,
                 composition_time_offset,
             } => {
                 if let Some(stream_id) = &self.active_stream_id {
+                    let is_keyframe_metadata = MetadataEntry::new(
+                        self.is_keyframe_metadata_key,
+                        MetadataValue::Bool(is_keyframe),
+                        &mut self.metadata_buffer,
+                    ).unwrap(); // Should only happen if type mismatch occurs
+
+                    let pts_offset_metadata = MetadataEntry::new(
+                        self.pts_offset_metadata_key,
+                        MetadataValue::I32(composition_time_offset),
+                        &mut self.metadata_buffer,
+                    ).unwrap(); // Should only happen if type mismatch occurs
+
+                    let metadata = MediaPayloadMetadataCollection::new(
+                        [is_keyframe_metadata, pts_offset_metadata].into_iter(),
+                        &mut self.metadata_buffer,
+                    );
+
                     outputs.media.push(MediaNotification {
                         stream_id: stream_id.clone(),
-                        content: MediaNotificationContent::Video {
-                            codec,
-                            timestamp: video_timestamp_from_rtmp_data(
-                                timestamp,
-                                composition_time_offset,
-                            ),
-                            is_keyframe,
-                            is_sequence_header,
+                        content: MediaNotificationContent::MediaPayload {
+                            media_type: MediaType::Video,
+                            payload_type: VIDEO_CODEC_H264_AVC.clone(),
+                            is_required_for_decoding: is_sequence_header,
+                            timestamp: Duration::from_millis(timestamp.value.into()),
+                            metadata,
                             data,
                         },
                     });

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
@@ -24,7 +24,6 @@ use mmids_rtmp::rtmp_server::{
     IpRestriction, RegistrationType, RtmpEndpointPublisherMessage, RtmpEndpointRequest,
     StreamKeyRegistration,
 };
-use mmids_rtmp::utils::video_timestamp_from_rtmp_data;
 use std::iter;
 use std::sync::Arc;
 use std::time::Duration;

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
@@ -13,7 +13,9 @@ use bytes::BytesMut;
 use futures::FutureExt;
 use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
-use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue};
+use mmids_core::workflows::metadata::{
+    MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue,
+};
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
@@ -310,13 +312,15 @@ impl FfmpegPullStep {
                         self.is_keyframe_metadata_key,
                         MetadataValue::Bool(is_keyframe),
                         &mut self.metadata_buffer,
-                    ).unwrap(); // Should only happen if type mismatch occurs
+                    )
+                    .unwrap(); // Should only happen if type mismatch occurs
 
                     let pts_offset_metadata = MetadataEntry::new(
                         self.pts_offset_metadata_key,
                         MetadataValue::I32(composition_time_offset),
                         &mut self.metadata_buffer,
-                    ).unwrap(); // Should only happen if type mismatch occurs
+                    )
+                    .unwrap(); // Should only happen if type mismatch occurs
 
                     let metadata = MediaPayloadMetadataCollection::new(
                         [is_keyframe_metadata, pts_offset_metadata].into_iter(),

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
@@ -37,8 +37,6 @@ struct FfmpegRtmpPushStep {
     definition: WorkflowStepDefinition,
     status: StepStatus,
     stream_reader: ExternalStreamReader,
-    is_keyframe_metadata_key: MetadataKey,
-    pts_offset_metadata_key: MetadataKey,
 }
 
 enum FutureResult {
@@ -101,8 +99,6 @@ impl StepGenerator for FfmpegRtmpPushStepGenerator {
             definition,
             status: StepStatus::Active,
             stream_reader: reader,
-            is_keyframe_metadata_key: self.is_keyframe_metadata_key,
-            pts_offset_metadata_key: self.pts_offset_metadata_key,
         };
 
         futures.push(notify_when_ffmpeg_endpoint_is_gone(self.ffmpeg_endpoint.clone()).boxed());

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
@@ -10,6 +10,7 @@ use crate::endpoint::{
 use crate::workflow_steps::ffmpeg_handler::{FfmpegHandlerGenerator, FfmpegParameterGenerator};
 use futures::FutureExt;
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
+use mmids_core::workflows::metadata::MetadataKey;
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
@@ -21,7 +22,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
-use mmids_core::workflows::metadata::MetadataKey;
 
 const TARGET: &str = "target";
 

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/mod.rs
@@ -22,7 +22,9 @@ use bytes::BytesMut;
 use futures::FutureExt;
 use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
-use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue};
+use mmids_core::workflows::metadata::{
+    MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue,
+};
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
@@ -34,7 +36,7 @@ use mmids_rtmp::rtmp_server::{
     RtmpEndpointPublisherMessage, RtmpEndpointRequest, RtmpEndpointWatcherNotification,
     StreamKeyRegistration,
 };
-use mmids_rtmp::utils::{stream_metadata_to_hash_map};
+use mmids_rtmp::utils::stream_metadata_to_hash_map;
 use std::collections::{HashMap, VecDeque};
 use std::iter;
 use std::sync::Arc;
@@ -459,11 +461,13 @@ impl FfmpegTranscoder {
                     if let WatchRegistrationStatus::Active { media_channel } =
                         &stream.rtmp_output_status
                     {
-                        if let Ok(media_data) = RtmpEndpointMediaData::from_media_notification_content(
-                            media.content,
-                            self.is_keyframe_metadata_key,
-                            self.pts_offset_metadata_key,
-                        ) {
+                        if let Ok(media_data) =
+                            RtmpEndpointMediaData::from_media_notification_content(
+                                media.content,
+                                self.is_keyframe_metadata_key,
+                                self.pts_offset_metadata_key,
+                            )
+                        {
                             let _ = media_channel.send(RtmpEndpointMediaMessage {
                                 stream_key: stream.id.0.clone(),
                                 data: media_data,
@@ -519,11 +523,13 @@ impl FfmpegTranscoder {
                 // so clients don't miss them
                 if let Some(media_channel) = output_media_channel {
                     for media in stream.pending_media.drain(..) {
-                        if let Ok(media_data) = RtmpEndpointMediaData::from_media_notification_content(
-                            media,
-                            self.is_keyframe_metadata_key,
-                            self.pts_offset_metadata_key,
-                        ) {
+                        if let Ok(media_data) =
+                            RtmpEndpointMediaData::from_media_notification_content(
+                                media,
+                                self.is_keyframe_metadata_key,
+                                self.pts_offset_metadata_key,
+                            )
+                        {
                             let _ = media_channel.send(RtmpEndpointMediaMessage {
                                 stream_key: stream.id.0.clone(),
                                 data: media_data,
@@ -763,13 +769,15 @@ impl FfmpegTranscoder {
                         self.is_keyframe_metadata_key,
                         MetadataValue::Bool(is_keyframe),
                         &mut self.metadata_buffer,
-                    ).unwrap(); // Only fails from type mismatch
+                    )
+                    .unwrap(); // Only fails from type mismatch
 
                     let pts_offset_metadata = MetadataEntry::new(
                         self.pts_offset_metadata_key,
                         MetadataValue::I32(composition_time_offset),
                         &mut self.metadata_buffer,
-                    ).unwrap(); // Only fails from type mismatch
+                    )
+                    .unwrap(); // Only fails from type mismatch
 
                     let metadata = MediaPayloadMetadataCollection::new(
                         [is_keyframe_metadata, pts_offset_metadata].into_iter(),
@@ -785,9 +793,9 @@ impl FfmpegTranscoder {
                             is_required_for_decoding: is_sequence_header,
                             data,
                             metadata,
-                        }
+                        },
                     })
-                },
+                }
 
                 RtmpEndpointPublisherMessage::NewAudioData {
                     publisher: _,

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/mod.rs
@@ -34,7 +34,7 @@ use mmids_rtmp::rtmp_server::{
     RtmpEndpointPublisherMessage, RtmpEndpointRequest, RtmpEndpointWatcherNotification,
     StreamKeyRegistration,
 };
-use mmids_rtmp::utils::{stream_metadata_to_hash_map, video_timestamp_from_rtmp_data};
+use mmids_rtmp::utils::{stream_metadata_to_hash_map};
 use std::collections::{HashMap, VecDeque};
 use std::iter;
 use std::sync::Arc;

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
@@ -8,13 +8,13 @@ use crate::workflow_steps::ffmpeg_transcode::{
 };
 use anyhow::Result;
 use bytes::{Bytes, BytesMut};
-use mmids_core::codecs::{VideoCodec, AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::net::ConnectionId;
 use mmids_core::workflows::definitions::{WorkflowStepDefinition, WorkflowStepType};
 use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataKey, MetadataKeyMap, MetadataValue};
 use mmids_core::workflows::steps::{StepStatus, StepTestContext};
 use mmids_core::workflows::{MediaNotification, MediaNotificationContent, MediaType};
-use mmids_core::{test_utils, StreamId, VideoTimestamp};
+use mmids_core::{test_utils, StreamId};
 use mmids_rtmp::rtmp_server::{
     RtmpEndpointMediaData, RtmpEndpointMediaMessage, RtmpEndpointPublisherMessage,
     RtmpEndpointRequest, RtmpEndpointWatcherNotification, StreamKeyRegistration,

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
@@ -11,7 +11,12 @@ use bytes::{Bytes, BytesMut};
 use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::net::ConnectionId;
 use mmids_core::workflows::definitions::{WorkflowStepDefinition, WorkflowStepType};
-use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataKey, MetadataKeyMap, MetadataValue};
+use mmids_core::workflows::metadata::common_metadata::{
+    get_is_keyframe_metadata_key, get_pts_offset_metadata_key,
+};
+use mmids_core::workflows::metadata::{
+    MediaPayloadMetadataCollection, MetadataKey, MetadataKeyMap, MetadataValue,
+};
 use mmids_core::workflows::steps::{StepStatus, StepTestContext};
 use mmids_core::workflows::{MediaNotification, MediaNotificationContent, MediaType};
 use mmids_core::{test_utils, StreamId};
@@ -27,7 +32,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use uuid::Uuid;
-use mmids_core::workflows::metadata::common_metadata::{get_is_keyframe_metadata_key, get_pts_offset_metadata_key};
 
 struct TestContext {
     step_context: StepTestContext,
@@ -739,9 +743,13 @@ async fn video_packet_sent_to_watcher_media_channel() {
         media.content,
         context.is_keyframe_metadata_key,
         context.pts_offset_metadata_key,
-    ).unwrap();
+    )
+    .unwrap();
 
-    assert_eq!(response.data, expected_endpoint_media_data, "Unexpected media sent");
+    assert_eq!(
+        response.data, expected_endpoint_media_data,
+        "Unexpected media sent"
+    );
 }
 
 #[tokio::test]
@@ -781,9 +789,13 @@ async fn audio_packet_sent_to_watcher_media_channel() {
         media.content,
         context.is_keyframe_metadata_key,
         context.pts_offset_metadata_key,
-    ).unwrap();
+    )
+    .unwrap();
 
-    assert_eq!(response.data, expected_endpoint_media_data, "Unexpected media sent");
+    assert_eq!(
+        response.data, expected_endpoint_media_data,
+        "Unexpected media sent"
+    );
 }
 
 #[tokio::test]
@@ -819,9 +831,13 @@ async fn metadata_packet_sent_to_watcher_media_channel() {
         media.content,
         context.is_keyframe_metadata_key,
         context.pts_offset_metadata_key,
-    ).unwrap();
+    )
+    .unwrap();
 
-    assert_eq!(response.data, expected_endpoint_media_data, "Unexpected media sent");
+    assert_eq!(
+        response.data, expected_endpoint_media_data,
+        "Unexpected media sent"
+    );
 }
 
 #[tokio::test]
@@ -908,7 +924,8 @@ async fn video_packet_from_publisher_passed_as_media_output() {
             is_required_for_decoding,
             metadata,
         } => {
-            let is_keyframe = metadata.iter()
+            let is_keyframe = metadata
+                .iter()
                 .filter(|m| m.key() == context.is_keyframe_metadata_key)
                 .filter_map(|m| match m.value() {
                     MetadataValue::Bool(val) => Some(val),
@@ -917,7 +934,8 @@ async fn video_packet_from_publisher_passed_as_media_output() {
                 .next()
                 .unwrap_or_default();
 
-            let pts_offset = metadata.iter()
+            let pts_offset = metadata
+                .iter()
                 .filter(|m| m.key() == context.pts_offset_metadata_key)
                 .filter_map(|m| match m.value() {
                     MetadataValue::I32(val) => Some(val),
@@ -927,10 +945,16 @@ async fn video_packet_from_publisher_passed_as_media_output() {
                 .unwrap_or_default();
 
             assert_eq!(*media_type, MediaType::Video);
-            assert_eq!(*payload_type, *VIDEO_CODEC_H264_AVC, "Unexpected payload type");
+            assert_eq!(
+                *payload_type, *VIDEO_CODEC_H264_AVC,
+                "Unexpected payload type"
+            );
             assert_eq!(data, &vec![1, 2, 3], "Unexpected bytes");
             assert_eq!(timestamp, &Duration::from_millis(5), "Unexpected dts");
-            assert!(is_required_for_decoding, "Expected is_required_for_decoding to be true");
+            assert!(
+                is_required_for_decoding,
+                "Expected is_required_for_decoding to be true"
+            );
             assert!(is_keyframe, "Expected is_keyframe to be true");
             assert_eq!(pts_offset, 123, "Unexpected pts offset");
         }

--- a/mmids-gstreamer/Cargo.toml
+++ b/mmids-gstreamer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 mmids-core = {path = "../mmids-core"}
 
-anyhow = "1.0.53"
+anyhow = "1.0"
 bytes = "1.1.0"
 futures = "0.3"
 gstreamer = "0.18.3"

--- a/mmids-gstreamer/src/encoders/audio_avenc_aac.rs
+++ b/mmids-gstreamer/src/encoders/audio_avenc_aac.rs
@@ -8,7 +8,8 @@ use bytes::{Bytes, BytesMut};
 use gstreamer::prelude::*;
 use gstreamer::{Element, FlowError, FlowSuccess, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
-use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW};
+use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
+use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use std::collections::HashMap;
 use std::iter;
@@ -16,7 +17,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, warn};
-use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 
 /// Creates an audio encoder that uses the gstreamer `avenc_aac` encoder to encode audio into aac.
 ///

--- a/mmids-gstreamer/src/encoders/audio_avenc_aac.rs
+++ b/mmids-gstreamer/src/encoders/audio_avenc_aac.rs
@@ -4,16 +4,19 @@ use crate::utils::{
     set_source_audio_sequence_header,
 };
 use anyhow::{anyhow, Context, Result};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use gstreamer::prelude::*;
 use gstreamer::{Element, FlowError, FlowSuccess, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
-use mmids_core::codecs::AudioCodec;
-use mmids_core::workflows::MediaNotificationContent;
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW};
+use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use std::collections::HashMap;
+use std::iter;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, warn};
+use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 
 /// Creates an audio encoder that uses the gstreamer `avenc_aac` encoder to encode audio into aac.
 ///
@@ -95,6 +98,7 @@ impl AvencAacEncoder {
             .map_err(|_| anyhow!("appsink could not be cast to `AppSink`"))?;
 
         let mut sent_codec_data = false;
+        let mut metadata_buffer = BytesMut::new();
         appsink.set_callbacks(
             AppSinkCallbacks::builder()
                 .new_sample(move |sink| {
@@ -103,6 +107,7 @@ impl AvencAacEncoder {
                         &mut sent_codec_data,
                         &output_parser,
                         media_sender.clone(),
+                        &mut metadata_buffer,
                     ) {
                         Ok(_) => Ok(FlowSuccess::Ok),
                         Err(error) => {
@@ -125,7 +130,7 @@ impl AvencAacEncoder {
 impl AudioEncoder for AvencAacEncoder {
     fn push_data(
         &self,
-        codec: AudioCodec,
+        payload_type: Arc<String>,
         data: Bytes,
         timestamp: Duration,
         is_sequence_header: bool,
@@ -134,7 +139,7 @@ impl AudioEncoder for AvencAacEncoder {
             .with_context(|| "Failed to create aac buffer")?;
 
         if is_sequence_header {
-            set_source_audio_sequence_header(&self.source, codec, buffer)
+            set_source_audio_sequence_header(&self.source, payload_type, buffer)
                 .with_context(|| " Failed to set aac sequence header into pipeline")?;
         } else {
             self.source
@@ -162,15 +167,18 @@ fn sample_received(
     codec_data_sent: &mut bool,
     output_parser: &Element,
     media_sender: UnboundedSender<MediaNotificationContent>,
+    metadata_buffer: &mut BytesMut,
 ) -> Result<()> {
     if !*codec_data_sent {
         // Pull the codec_data out of the output parser to get the sequence header
         let codec_data = get_codec_data_from_element(output_parser)?;
-        let _ = media_sender.send(MediaNotificationContent::Audio {
-            codec: AudioCodec::Aac,
+        let _ = media_sender.send(MediaNotificationContent::MediaPayload {
+            payload_type: AUDIO_CODEC_AAC_RAW.clone(),
+            media_type: MediaType::Audio,
             timestamp: Duration::from_millis(0),
-            is_sequence_header: true,
+            is_required_for_decoding: true,
             data: codec_data,
+            metadata: MediaPayloadMetadataCollection::new(iter::empty(), metadata_buffer),
         });
 
         *codec_data_sent = true;
@@ -179,11 +187,13 @@ fn sample_received(
     let sample = SampleResult::from_sink(sink).with_context(|| "Failed to get aac sample")?;
 
     if let Some(dts) = sample.dts {
-        let _ = media_sender.send(MediaNotificationContent::Audio {
-            codec: AudioCodec::Aac,
+        let _ = media_sender.send(MediaNotificationContent::MediaPayload {
+            payload_type: AUDIO_CODEC_AAC_RAW.clone(),
+            media_type: MediaType::Audio,
             timestamp: dts,
-            is_sequence_header: false,
+            is_required_for_decoding: false,
             data: sample.content,
+            metadata: MediaPayloadMetadataCollection::new(iter::empty(), metadata_buffer),
         });
 
         Ok(())

--- a/mmids-gstreamer/src/encoders/audio_copy.rs
+++ b/mmids-gstreamer/src/encoders/audio_copy.rs
@@ -5,6 +5,7 @@ use bytes::{Bytes, BytesMut};
 use gstreamer::prelude::*;
 use gstreamer::{Element, FlowError, FlowSuccess, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
+use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use std::collections::HashMap;
 use std::iter;
@@ -12,7 +13,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
-use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 
 /// Generates an audio encoder that passes audio packets to the output channel without modification.
 pub struct AudioCopyEncoderGenerator {}

--- a/mmids-gstreamer/src/encoders/audio_copy.rs
+++ b/mmids-gstreamer/src/encoders/audio_copy.rs
@@ -1,17 +1,18 @@
 use crate::encoders::{AudioEncoder, AudioEncoderGenerator, SampleResult};
 use crate::utils::{create_gst_element, set_gst_buffer};
 use anyhow::{anyhow, Context, Result};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use gstreamer::prelude::*;
 use gstreamer::{Element, FlowError, FlowSuccess, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
-use mmids_core::codecs::AudioCodec;
-use mmids_core::workflows::MediaNotificationContent;
+use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use std::collections::HashMap;
+use std::iter;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
+use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 
 /// Generates an audio encoder that passes audio packets to the output channel without modification.
 pub struct AudioCopyEncoderGenerator {}
@@ -28,7 +29,7 @@ impl AudioEncoderGenerator for AudioCopyEncoderGenerator {
 }
 
 struct CodecInfo {
-    codec: AudioCodec,
+    payload_type: Arc<String>,
     sequence_header: Bytes,
 }
 
@@ -64,47 +65,57 @@ impl AudioCopyEncoder {
         let copy_of_codec_data = codec_data.clone();
         let mut sent_codec_data = false;
         let mut codec_data_error_raised = false;
-        let mut codec = AudioCodec::Unknown;
+        let mut metadata_buffer = BytesMut::new();
         appsink.set_callbacks(
             AppSinkCallbacks::builder()
                 .new_sample(move |sink| {
-                    if !sent_codec_data {
-                        let data = match copy_of_codec_data.lock() {
-                            Ok(data) => data,
-                            Err(_) => {
-                                if !codec_data_error_raised {
-                                    error!("codec data lock was poisoned");
-                                    codec_data_error_raised = true;
-                                }
-
-                                return Err(FlowError::Error);
+                    let data = match copy_of_codec_data.lock() {
+                        Ok(data) => data,
+                        Err(_) => {
+                            if !codec_data_error_raised {
+                                error!("codec data lock was poisoned");
+                                codec_data_error_raised = true;
                             }
-                        };
 
-                        if let Some(info) = &*data {
-                            let _ = media_sender.send(MediaNotificationContent::Audio {
-                                codec: info.codec,
-                                data: info.sequence_header.clone(),
-                                timestamp: Duration::new(0, 0),
-                                is_sequence_header: true,
-                            });
-
-                            codec = info.codec;
-                            sent_codec_data = true;
-                        } else if !codec_data_error_raised {
-                            error!("Received data prior to codec data being set. This shouldn't happen");
-                            codec_data_error_raised = true;
+                            return Err(FlowError::Error);
                         }
+                    };
+
+                    let info = match &*data {
+                        Some(info) => info,
+                        None => {
+                            if !codec_data_error_raised {
+                                error!("Received data prior to codec data being set. This shouldn't happen");
+                                codec_data_error_raised = true;
+                            }
+
+                            return Err(FlowError::Error);
+                        }
+                    };
+
+                    if !sent_codec_data {
+                        let _ = media_sender.send(MediaNotificationContent::MediaPayload {
+                            payload_type: info.payload_type.clone(),
+                            media_type: MediaType::Audio,
+                            data: info.sequence_header.clone(),
+                            timestamp: Duration::new(0, 0),
+                            metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut metadata_buffer),
+                            is_required_for_decoding: true,
+                        });
+
+                        sent_codec_data = true;
                     }
 
                     let sample = SampleResult::from_sink(sink)
                         .map_err(|_| FlowError::CustomError)?;
 
-                    let _ = media_sender.send(MediaNotificationContent::Audio {
-                        codec,
+                    let _ = media_sender.send(MediaNotificationContent::MediaPayload {
+                        payload_type: info.payload_type.clone(),
+                        media_type: MediaType::Audio,
                         data: sample.content,
                         timestamp: sample.dts.unwrap_or(Duration::new(0, 0)),
-                        is_sequence_header: false,
+                        metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut metadata_buffer),
+                        is_required_for_decoding: false,
                     });
 
                     Ok(FlowSuccess::Ok)
@@ -126,7 +137,7 @@ impl AudioCopyEncoder {
 impl AudioEncoder for AudioCopyEncoder {
     fn push_data(
         &self,
-        codec: AudioCodec,
+        payload_type: Arc<String>,
         data: Bytes,
         timestamp: Duration,
         is_sequence_header: bool,
@@ -138,7 +149,7 @@ impl AudioEncoder for AudioCopyEncoder {
                 .map_err(|_| anyhow!("Audio copy encoder's lock was poisoned"))?;
 
             *codec_data = Some(CodecInfo {
-                codec,
+                payload_type,
                 sequence_header: data,
             })
         } else {

--- a/mmids-gstreamer/src/encoders/audio_drop.rs
+++ b/mmids-gstreamer/src/encoders/audio_drop.rs
@@ -5,6 +5,7 @@ use gstreamer::Pipeline;
 use mmids_core::codecs::AudioCodec;
 use mmids_core::workflows::MediaNotificationContent;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -27,7 +28,7 @@ struct AudioDropEncoder {}
 impl AudioEncoder for AudioDropEncoder {
     fn push_data(
         &self,
-        _codec: AudioCodec,
+        _codec: Arc<String>,
         _data: Bytes,
         _timestamp: Duration,
         _is_sequence_header: bool,

--- a/mmids-gstreamer/src/encoders/audio_drop.rs
+++ b/mmids-gstreamer/src/encoders/audio_drop.rs
@@ -2,7 +2,6 @@ use crate::encoders::{AudioEncoder, AudioEncoderGenerator};
 use anyhow::Result;
 use bytes::Bytes;
 use gstreamer::Pipeline;
-use mmids_core::codecs::AudioCodec;
 use mmids_core::workflows::MediaNotificationContent;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/mmids-gstreamer/src/encoders/mod.rs
+++ b/mmids-gstreamer/src/encoders/mod.rs
@@ -12,7 +12,6 @@ use anyhow::{Context, Result};
 use bytes::Bytes;
 use gstreamer::{Format, GenericFormattedValue, Pipeline};
 use gstreamer_app::AppSink;
-use mmids_core::codecs::VideoCodec;
 use mmids_core::workflows::MediaNotificationContent;
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;

--- a/mmids-gstreamer/src/encoders/mod.rs
+++ b/mmids-gstreamer/src/encoders/mod.rs
@@ -36,7 +36,7 @@ pub trait VideoEncoder {
     /// Pushes a video frame into the encoder's pipeline
     fn push_data(
         &self,
-        codec: VideoCodec,
+        payload_type: Arc<String>,
         data: Bytes,
         timestamp: VideoTimestamp,
         is_sequence_header: bool,

--- a/mmids-gstreamer/src/encoders/mod.rs
+++ b/mmids-gstreamer/src/encoders/mod.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use bytes::Bytes;
 use gstreamer::{Format, GenericFormattedValue, Pipeline};
 use gstreamer_app::AppSink;
-use mmids_core::codecs::{AudioCodec, VideoCodec};
+use mmids_core::codecs::VideoCodec;
 use mmids_core::workflows::MediaNotificationContent;
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;

--- a/mmids-gstreamer/src/encoders/mod.rs
+++ b/mmids-gstreamer/src/encoders/mod.rs
@@ -17,6 +17,7 @@ use mmids_core::workflows::MediaNotificationContent;
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;
 use std::default::Default;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -49,7 +50,7 @@ pub trait AudioEncoder {
     /// Pushes an audio frame into the encoder's pipeline
     fn push_data(
         &self,
-        codec: AudioCodec,
+        payload_type: Arc<String>,
         data: Bytes,
         timestamp: Duration,
         is_sequence_header: bool,

--- a/mmids-gstreamer/src/encoders/video_copy.rs
+++ b/mmids-gstreamer/src/encoders/video_copy.rs
@@ -6,6 +6,9 @@ use gstreamer::prelude::*;
 use gstreamer::{Element, FlowError, FlowSuccess, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
 use mmids_core::codecs::VIDEO_CODEC_H264_AVC;
+use mmids_core::workflows::metadata::{
+    MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue,
+};
 use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;
@@ -14,7 +17,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
-use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue};
 
 /// Creates an encoder that passes video packets through to the output channel without modification
 pub struct VideoCopyEncoderGenerator {
@@ -28,7 +30,11 @@ impl VideoEncoderGenerator for VideoCopyEncoderGenerator {
         _parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
     ) -> Result<Box<dyn VideoEncoder>> {
-        Ok(Box::new(VideoCopyEncoder::new(media_sender, pipeline, self.pts_offset_metadata_key)?))
+        Ok(Box::new(VideoCopyEncoder::new(
+            media_sender,
+            pipeline,
+            self.pts_offset_metadata_key,
+        )?))
     }
 }
 

--- a/mmids-gstreamer/src/encoders/video_copy.rs
+++ b/mmids-gstreamer/src/encoders/video_copy.rs
@@ -1,20 +1,25 @@
 use crate::encoders::{SampleResult, VideoEncoder, VideoEncoderGenerator};
 use crate::utils::create_gst_element;
 use anyhow::{anyhow, Context, Result};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use gstreamer::prelude::*;
 use gstreamer::{Element, FlowError, FlowSuccess, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
-use mmids_core::codecs::VideoCodec;
-use mmids_core::workflows::MediaNotificationContent;
+use mmids_core::codecs::{VIDEO_CODEC_H264_AVC, VideoCodec};
+use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;
+use std::iter;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
+use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue};
 
 /// Creates an encoder that passes video packets through to the output channel without modification
-pub struct VideoCopyEncoderGenerator {}
+pub struct VideoCopyEncoderGenerator {
+    pub pts_offset_metadata_key: MetadataKey,
+}
 
 impl VideoEncoderGenerator for VideoCopyEncoderGenerator {
     fn create(
@@ -23,7 +28,7 @@ impl VideoEncoderGenerator for VideoCopyEncoderGenerator {
         _parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
     ) -> Result<Box<dyn VideoEncoder>> {
-        Ok(Box::new(VideoCopyEncoder::new(media_sender, pipeline)?))
+        Ok(Box::new(VideoCopyEncoder::new(media_sender, pipeline, self.pts_offset_metadata_key)?))
     }
 }
 
@@ -41,6 +46,7 @@ impl VideoCopyEncoder {
     fn new(
         media_sender: UnboundedSender<MediaNotificationContent>,
         pipeline: &Pipeline,
+        pts_offset_metadata_key: MetadataKey,
     ) -> Result<VideoCopyEncoder> {
         // While we won't be mutating the stream, we want to pass it through a gstreamer pipeline
         // so the packets will be synchronized with audio in case of transcoding delay.
@@ -65,6 +71,7 @@ impl VideoCopyEncoder {
         let mut sent_codec_data = false;
         let mut codec_data_error_raised = false;
         let mut codec = VideoCodec::Unknown;
+        let mut metadata_buffer = BytesMut::new();
         appsink.set_callbacks(
             AppSinkCallbacks::builder()
                 .new_sample(move |sink| {
@@ -82,12 +89,13 @@ impl VideoCopyEncoder {
                         };
 
                         if let Some(info) = &*data {
-                            let _ = media_sender.send(MediaNotificationContent::Video {
-                                codec: info.codec,
+                            let _ = media_sender.send(MediaNotificationContent::MediaPayload {
+                                media_type: MediaType::Video,
+                                payload_type: VIDEO_CODEC_H264_AVC.clone(),
+                                timestamp: Duration::new(0, 0),
+                                is_required_for_decoding: true,
                                 data: info.sequence_header.clone(),
-                                timestamp: VideoTimestamp::from_zero(),
-                                is_keyframe: false,
-                                is_sequence_header: true,
+                                metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut metadata_buffer),
                             });
 
                             codec = info.codec;
@@ -102,12 +110,22 @@ impl VideoCopyEncoder {
                         .map_err(|_| FlowError::CustomError)?;
 
                     let timestamp = sample.to_video_timestamp();
-                    let _ = media_sender.send(MediaNotificationContent::Video {
-                        codec,
+                    let pts_offset = MetadataEntry::new(
+                        pts_offset_metadata_key,
+                        MetadataValue::I32(timestamp.pts_offset()),
+                        &mut metadata_buffer,
+                    ).unwrap(); // Can only panic if the key is not for an i32
+
+                    let _ = media_sender.send(MediaNotificationContent::MediaPayload {
+                        media_type: MediaType::Video,
+                        payload_type: VIDEO_CODEC_H264_AVC.clone(),
+                        timestamp: timestamp.dts(),
+                        is_required_for_decoding: false,
                         data: sample.content,
-                        timestamp,
-                        is_sequence_header: false,
-                        is_keyframe: false, // TODO: preserve this somehow
+                        metadata: MediaPayloadMetadataCollection::new(
+                            [pts_offset].into_iter(),
+                            &mut metadata_buffer,
+                        ),
                     });
 
                     Ok(FlowSuccess::Ok)

--- a/mmids-gstreamer/src/encoders/video_copy.rs
+++ b/mmids-gstreamer/src/encoders/video_copy.rs
@@ -5,7 +5,7 @@ use bytes::{Bytes, BytesMut};
 use gstreamer::prelude::*;
 use gstreamer::{Element, FlowError, FlowSuccess, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
-use mmids_core::codecs::{VIDEO_CODEC_H264_AVC, VideoCodec};
+use mmids_core::codecs::VIDEO_CODEC_H264_AVC;
 use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;
@@ -33,7 +33,6 @@ impl VideoEncoderGenerator for VideoCopyEncoderGenerator {
 }
 
 struct CodecInfo {
-    payload_type: Arc<String>,
     sequence_header: Bytes,
 }
 
@@ -145,7 +144,7 @@ impl VideoCopyEncoder {
 impl VideoEncoder for VideoCopyEncoder {
     fn push_data(
         &self,
-        payload_type: Arc<String>,
+        _payload_type: Arc<String>,
         data: Bytes,
         timestamp: VideoTimestamp,
         is_sequence_header: bool,
@@ -157,7 +156,6 @@ impl VideoEncoder for VideoCopyEncoder {
                 .map_err(|_| anyhow!("Video copy encoder's lock was poisoned"))?;
 
             *codec_data = Some(CodecInfo {
-                payload_type,
                 sequence_header: data,
             })
         } else {

--- a/mmids-gstreamer/src/encoders/video_drop.rs
+++ b/mmids-gstreamer/src/encoders/video_drop.rs
@@ -1,7 +1,6 @@
 use crate::encoders::{VideoEncoder, VideoEncoderGenerator};
 use bytes::Bytes;
 use gstreamer::Pipeline;
-use mmids_core::codecs::VideoCodec;
 use mmids_core::workflows::MediaNotificationContent;
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;

--- a/mmids-gstreamer/src/encoders/video_drop.rs
+++ b/mmids-gstreamer/src/encoders/video_drop.rs
@@ -5,6 +5,7 @@ use mmids_core::codecs::VideoCodec;
 use mmids_core::workflows::MediaNotificationContent;
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 
 /// Creates a video encoder that drops audio.
@@ -26,7 +27,7 @@ struct VideoDropEncoder {}
 impl VideoEncoder for VideoDropEncoder {
     fn push_data(
         &self,
-        _codec: VideoCodec,
+        _payload: Arc<String>,
         _data: Bytes,
         _timestamp: VideoTimestamp,
         _is_sequence_header: bool,

--- a/mmids-gstreamer/src/encoders/video_x264.rs
+++ b/mmids-gstreamer/src/encoders/video_x264.rs
@@ -5,7 +5,7 @@ use bytes::{Bytes, BytesMut};
 use gstreamer::prelude::*;
 use gstreamer::{Caps, Element, FlowError, FlowSuccess, Fraction, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
-use mmids_core::codecs::{VIDEO_CODEC_H264_AVC, VideoCodec};
+use mmids_core::codecs::VIDEO_CODEC_H264_AVC;
 use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;

--- a/mmids-gstreamer/src/encoders/video_x264.rs
+++ b/mmids-gstreamer/src/encoders/video_x264.rs
@@ -6,6 +6,9 @@ use gstreamer::prelude::*;
 use gstreamer::{Caps, Element, FlowError, FlowSuccess, Fraction, Pipeline};
 use gstreamer_app::{AppSink, AppSinkCallbacks, AppSrc};
 use mmids_core::codecs::VIDEO_CODEC_H264_AVC;
+use mmids_core::workflows::metadata::{
+    MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue,
+};
 use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;
@@ -14,7 +17,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, warn};
-use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue};
 
 /// Creates a video encoder that uses the gstreamer `x264enc` encoder to encode video into h264
 /// video.
@@ -246,7 +248,8 @@ fn sample_received(
         pts_offset_metadata_key,
         MetadataValue::I32(timestamp.pts_offset()),
         metadata_buffer,
-    ).unwrap(); // Can only panic if the key is not for an i32
+    )
+    .unwrap(); // Can only panic if the key is not for an i32
 
     let _ = media_sender.send(MediaNotificationContent::MediaPayload {
         media_type: MediaType::Video,
@@ -254,10 +257,7 @@ fn sample_received(
         timestamp: timestamp.dts(),
         is_required_for_decoding: false,
         data: sample.content,
-        metadata: MediaPayloadMetadataCollection::new(
-            [pts_offset].into_iter(),
-            metadata_buffer,
-        ),
+        metadata: MediaPayloadMetadataCollection::new([pts_offset].into_iter(), metadata_buffer),
     });
 
     Ok(())

--- a/mmids-gstreamer/src/encoders/video_x264.rs
+++ b/mmids-gstreamer/src/encoders/video_x264.rs
@@ -10,6 +10,7 @@ use mmids_core::workflows::{MediaNotificationContent, MediaType};
 use mmids_core::VideoTimestamp;
 use std::collections::HashMap;
 use std::iter;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{error, warn};
@@ -182,7 +183,7 @@ impl X264Encoder {
 impl VideoEncoder for X264Encoder {
     fn push_data(
         &self,
-        codec: VideoCodec,
+        payload_type: Arc<String>,
         data: Bytes,
         timestamp: VideoTimestamp,
         is_sequence_header: bool,
@@ -192,7 +193,7 @@ impl VideoEncoder for X264Encoder {
                 .with_context(|| "Failed to set buffer")?;
 
         if is_sequence_header {
-            crate::utils::set_source_video_sequence_header(&self.source, codec, buffer)
+            crate::utils::set_source_video_sequence_header(&self.source, payload_type, buffer)
                 .with_context(|| "Failed to set sequence header for x264 encoder")?;
         } else {
             self.source

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
+use mmids_core::workflows::metadata::MetadataKey;
 
 /// Requests that can be made to the gstreamer transcoding endpoint
 pub enum GstTranscoderRequest {
@@ -122,9 +123,10 @@ struct StartTranscodeParams {
 /// endpoint can be made.
 pub fn start_gst_transcoder(
     encoder_factory: Arc<EncoderFactory>,
+    pts_offset_metadata_key: MetadataKey,
 ) -> Result<UnboundedSender<GstTranscoderRequest>, EndpointStartError> {
     let (sender, receiver) = unbounded_channel();
-    let actor = EndpointActor::new(receiver, encoder_factory)?;
+    let actor = EndpointActor::new(receiver, encoder_factory, pts_offset_metadata_key)?;
     tokio::spawn(actor.run());
 
     Ok(sender)
@@ -148,6 +150,7 @@ struct EndpointActor {
     futures: FuturesUnordered<BoxFuture<'static, EndpointFuturesResult>>,
     active_transcodes: HashMap<Uuid, ActiveTranscode>,
     encoder_factory: Arc<EncoderFactory>,
+    pts_offset_metadata_key: MetadataKey,
 }
 
 unsafe impl Send for EndpointActor {}
@@ -157,6 +160,7 @@ impl EndpointActor {
     fn new(
         receiver: UnboundedReceiver<GstTranscoderRequest>,
         encoder_factory: Arc<EncoderFactory>,
+        pts_offset_metadata_key: MetadataKey,
     ) -> Result<EndpointActor, EndpointStartError> {
         (*GSTREAMER_INIT_RESULT).as_ref()?;
 
@@ -167,6 +171,7 @@ impl EndpointActor {
             futures,
             active_transcodes: HashMap::new(),
             encoder_factory,
+            pts_offset_metadata_key,
         })
     }
 
@@ -330,7 +335,7 @@ impl EndpointActor {
             process_id: params.id,
         };
 
-        let manager = start_transcode_manager(parameters);
+        let manager = start_transcode_manager(parameters, self.pts_offset_metadata_key);
 
         let _ = params
             .notification_channel

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
@@ -10,13 +10,13 @@ use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
 use gstreamer::{glib, Pipeline};
+use mmids_core::workflows::metadata::MetadataKey;
 use mmids_core::workflows::MediaNotificationContent;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
-use mmids_core::workflows::metadata::MetadataKey;
 
 /// Requests that can be made to the gstreamer transcoding endpoint
 pub enum GstTranscoderRequest {

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
@@ -192,15 +192,17 @@ impl TranscodeManager {
                 }
             }
 
-            MediaNotificationContent::Audio {
+            MediaNotificationContent::MediaPayload {
                 timestamp,
-                codec,
+                payload_type,
+                media_type: _,
                 data,
-                is_sequence_header,
+                metadata: _,
+                is_required_for_decoding,
             } => {
                 let result =
                     self.audio_encoder
-                        .push_data(codec, data, timestamp, is_sequence_header);
+                        .push_data(payload_type, data, timestamp, is_required_for_decoding);
 
                 if let Err(error) = result {
                     error!("Failed to push media to audio encoder: {}", error);

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
@@ -200,9 +200,12 @@ impl TranscodeManager {
                 metadata: _,
                 is_required_for_decoding,
             } => {
-                let result =
-                    self.audio_encoder
-                        .push_data(payload_type, data, timestamp, is_required_for_decoding);
+                let result = self.audio_encoder.push_data(
+                    payload_type,
+                    data,
+                    timestamp,
+                    is_required_for_decoding,
+                );
 
                 if let Err(error) = result {
                     error!("Failed to push media to audio encoder: {}", error);

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
@@ -11,8 +11,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, instrument};
 use uuid::Uuid;
 use mmids_core::VideoTimestamp;
-use mmids_core::workflows::metadata::{MetadataKey, MetadataKeyMap, MetadataValue};
-use mmids_core::workflows::metadata::common_metadata::get_pts_offset_metadata_key;
+use mmids_core::workflows::metadata::{MetadataKey, MetadataValue};
 
 pub enum TranscodeManagerRequest {
     StopTranscode,

--- a/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
+++ b/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
@@ -212,12 +212,6 @@ impl BasicTranscodeStep {
                 outputs.media.push(media);
             }
 
-            MediaNotificationContent::Video { .. } => {
-                if let Some(transcode) = self.active_transcodes.get(&media.stream_id) {
-                    let _ = transcode.media_sender.send(media.content.clone());
-                }
-            }
-
             MediaNotificationContent::MediaPayload { .. } => {
                 if let Some(transcode) = self.active_transcodes.get(&media.stream_id) {
                     let _ = transcode.media_sender.send(media.content.clone());

--- a/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
+++ b/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
@@ -218,12 +218,6 @@ impl BasicTranscodeStep {
                 }
             }
 
-            MediaNotificationContent::Audio { .. } => {
-                if let Some(transcode) = self.active_transcodes.get(&media.stream_id) {
-                    let _ = transcode.media_sender.send(media.content.clone());
-                }
-            }
-
             MediaNotificationContent::MediaPayload { .. } => {
                 if let Some(transcode) = self.active_transcodes.get(&media.stream_id) {
                     let _ = transcode.media_sender.send(media.content.clone());

--- a/mmids-gstreamer/src/utils.rs
+++ b/mmids-gstreamer/src/utils.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use gstreamer::prelude::*;
 use gstreamer::{Buffer, Caps, ClockTime, Element, ElementFactory};
 use gstreamer_app::AppSrc;
-use mmids_core::codecs::{VideoCodec, AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/mmids-gstreamer/src/utils.rs
+++ b/mmids-gstreamer/src/utils.rs
@@ -1,13 +1,13 @@
 //! Common utility functions that are useful for interacting with gstreamer.  These are mostly
 //! meant for use by code creating custom encoders.
 
-use std::sync::Arc;
 use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
 use gstreamer::prelude::*;
 use gstreamer::{Buffer, Caps, ClockTime, Element, ElementFactory};
 use gstreamer_app::AppSrc;
-use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, AudioCodec, VideoCodec};
+use mmids_core::codecs::{VideoCodec, AUDIO_CODEC_AAC_RAW};
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Function that makes it easy to create a gstreamer `Buffer` based on a set of bytes, an optional
@@ -89,7 +89,7 @@ pub fn set_source_audio_sequence_header(
         other => Err(anyhow!(
             "audio codec {other} is not known, and thus we can't prepare the gstreamer pipeline \
             to accept it."
-        ))
+        )),
     }
 }
 

--- a/mmids-gstreamer/src/utils.rs
+++ b/mmids-gstreamer/src/utils.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use gstreamer::prelude::*;
 use gstreamer::{Buffer, Caps, ClockTime, Element, ElementFactory};
 use gstreamer_app::AppSrc;
-use mmids_core::codecs::{VideoCodec, AUDIO_CODEC_AAC_RAW};
+use mmids_core::codecs::{VideoCodec, AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,24 +48,22 @@ pub fn set_gst_buffer(data: Bytes, dts: Option<Duration>, pts: Option<Duration>)
 /// so it can be utilized, and this provides a central function for that logic.
 pub fn set_source_video_sequence_header(
     source: &AppSrc,
-    codec: VideoCodec,
+    payload_type: Arc<String>,
     buffer: Buffer,
 ) -> Result<()> {
-    match codec {
-        VideoCodec::H264 => {
-            let caps = Caps::builder("video/x-h264")
-                .field("codec_data", buffer)
-                .build();
+    if payload_type == *VIDEO_CODEC_H264_AVC {
+        let caps = Caps::builder("video/x-h264")
+            .field("codec_data", buffer)
+            .build();
 
-            source.set_caps(Some(&caps));
+        source.set_caps(Some(&caps));
 
-            Ok(())
-        }
-
-        VideoCodec::Unknown => Err(anyhow!(
+        Ok(())
+    } else {
+        Err(anyhow!(
             "Video codec is not known, and thus we can't prepare the gstreamer pipeline to \
                 accept it."
-        )),
+        ))
     }
 }
 

--- a/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
@@ -92,7 +92,6 @@ pub struct VideoSequenceHeader {
 }
 
 pub struct AudioSequenceHeader {
-    pub codec: AudioCodec,
     pub data: Bytes,
 }
 

--- a/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
@@ -4,7 +4,7 @@ use crate::rtmp_server::{
     IpRestriction, RtmpEndpointMediaData, RtmpEndpointMediaMessage,
     RtmpEndpointWatcherNotification, ValidationResponse,
 };
-use mmids_core::codecs::{AudioCodec, VideoCodec};
+use mmids_core::codecs::VideoCodec;
 
 use bytes::Bytes;
 use futures::future::BoxFuture;

--- a/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
@@ -4,8 +4,6 @@ use crate::rtmp_server::{
     IpRestriction, RtmpEndpointMediaData, RtmpEndpointMediaMessage,
     RtmpEndpointWatcherNotification, ValidationResponse,
 };
-use mmids_core::codecs::VideoCodec;
-
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;

--- a/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/actor_types.rs
@@ -87,7 +87,6 @@ pub struct WatcherRegistrant {
 }
 
 pub struct VideoSequenceHeader {
-    pub codec: VideoCodec,
     pub data: Bytes,
 }
 

--- a/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
@@ -30,7 +30,6 @@ pub struct RtmpServerConnectionHandler {
     request_sender: UnboundedSender<ConnectionRequest>,
     force_disconnect: bool,
     published_event_channel: Option<UnboundedSender<RtmpEndpointPublisherMessage>>,
-    video_parse_error_raised: bool,
 }
 
 #[derive(Debug)]
@@ -114,7 +113,6 @@ enum FutureResult {
 }
 
 struct UnwrappedVideo {
-    codec: VideoCodec,
     is_keyframe: bool,
     is_sequence_header: bool,
     data: Bytes,
@@ -142,7 +140,6 @@ impl RtmpServerConnectionHandler {
             request_sender,
             force_disconnect: false,
             published_event_channel: None,
-            video_parse_error_raised: false,
         }
     }
 
@@ -634,7 +631,6 @@ impl RtmpServerConnectionHandler {
 
                 let UnwrappedVideo {
                     data,
-                    codec,
                     is_keyframe,
                     is_sequence_header: is_parameter_set,
                     composition_time_in_ms,
@@ -1008,7 +1004,6 @@ impl RtmpServerConnectionHandler {
 fn unwrap_video_from_flv(mut data: Bytes) -> UnwrappedVideo {
     if data.len() < 2 {
         return UnwrappedVideo {
-            codec: VideoCodec::Unknown,
             is_keyframe: false,
             is_sequence_header: false,
             data,
@@ -1039,7 +1034,6 @@ fn unwrap_video_from_flv(mut data: Bytes) -> UnwrappedVideo {
     };
 
     UnwrappedVideo {
-        codec,
         is_keyframe,
         is_sequence_header,
         data,

--- a/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
@@ -1003,7 +1003,9 @@ impl RtmpServerConnectionHandler {
 
 fn unwrap_video_from_flv(mut data: Bytes) -> Result<UnwrappedVideo> {
     if data.len() < 2 {
-        return Err(anyhow!("FLV segment had less than 2 bytes, and thus invalid"));
+        return Err(anyhow!(
+            "FLV segment had less than 2 bytes, and thus invalid"
+        ));
     }
 
     let flv_tag = data.split_to(1);
@@ -1043,7 +1045,9 @@ fn wrap_video_into_flv(
     let avc_type = if is_sequence_header { 0 } else { 1 };
 
     let mut pts_value = Vec::new();
-    pts_value.write_i24::<BigEndian>(composition_time_offset).unwrap(); // shouldn't fail
+    pts_value
+        .write_i24::<BigEndian>(composition_time_offset)
+        .unwrap(); // shouldn't fail
 
     let mut wrapped = BytesMut::new();
     wrapped.put_u8(flv_tag);

--- a/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
@@ -631,7 +631,6 @@ impl RtmpServerConnectionHandler {
                     Ok(video) => video,
                     Err(error) => {
                         error!("Video is using an unsupported set of flv video tags: {error}");
-                        self.force_disconnect = true;
 
                         return;
                     }

--- a/mmids-rtmp/src/rtmp_server/actor/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/mod.rs
@@ -356,13 +356,11 @@ impl RtmpServerEndpointActor {
 
             RtmpEndpointMediaData::NewAudioData {
                 data,
-                codec,
                 is_sequence_header,
                 ..
             } => {
                 if *is_sequence_header {
                     key_details.latest_audio_sequence_header = Some(AudioSequenceHeader {
-                        codec: *codec,
                         data: data.clone(),
                     });
                 }
@@ -1232,7 +1230,6 @@ fn handle_connection_request_watch(
 
     if let Some(sequence_header) = &active_stream_key.latest_audio_sequence_header {
         let _ = media_sender.send(RtmpEndpointMediaData::NewAudioData {
-            codec: sequence_header.codec,
             data: sequence_header.data.clone(),
             is_sequence_header: true,
             timestamp: RtmpTimestamp::new(0),

--- a/mmids-rtmp/src/rtmp_server/actor/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/mod.rs
@@ -342,13 +342,11 @@ impl RtmpServerEndpointActor {
         match &data {
             RtmpEndpointMediaData::NewVideoData {
                 data,
-                codec,
                 is_sequence_header,
                 ..
             } => {
                 if *is_sequence_header {
                     key_details.latest_video_sequence_header = Some(VideoSequenceHeader {
-                        codec: *codec,
                         data: data.clone(),
                     });
                 }
@@ -1218,7 +1216,6 @@ fn handle_connection_request_watch(
     // start decoding video
     if let Some(sequence_header) = &active_stream_key.latest_video_sequence_header {
         let _ = media_sender.send(RtmpEndpointMediaData::NewVideoData {
-            codec: sequence_header.codec,
             is_sequence_header: true,
             is_keyframe: true,
             data: sequence_header.data.clone(),

--- a/mmids-rtmp/src/rtmp_server/actor/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/mod.rs
@@ -346,9 +346,8 @@ impl RtmpServerEndpointActor {
                 ..
             } => {
                 if *is_sequence_header {
-                    key_details.latest_video_sequence_header = Some(VideoSequenceHeader {
-                        data: data.clone(),
-                    });
+                    key_details.latest_video_sequence_header =
+                        Some(VideoSequenceHeader { data: data.clone() });
                 }
             }
 

--- a/mmids-rtmp/src/rtmp_server/actor/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/mod.rs
@@ -360,9 +360,8 @@ impl RtmpServerEndpointActor {
                 ..
             } => {
                 if *is_sequence_header {
-                    key_details.latest_audio_sequence_header = Some(AudioSequenceHeader {
-                        data: data.clone(),
-                    });
+                    key_details.latest_audio_sequence_header =
+                        Some(AudioSequenceHeader { data: data.clone() });
                 }
             }
 

--- a/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
@@ -1070,7 +1070,7 @@ async fn notification_raised_when_audio_published() {
     let mut context = TestContextBuilder::new().into_publisher().await;
     context.set_as_active_publisher().await;
 
-    let data = Bytes::from(vec![1, 2, 3, 4]);
+    let data = Bytes::from(vec![0xa0, 2, 3, 4]);
     let timestamp = RtmpTimestamp::new(5);
     context.client.publish_audio(data.clone(), timestamp);
 

--- a/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
@@ -876,7 +876,7 @@ async fn notification_raised_when_video_published() {
     let mut context = TestContextBuilder::new().into_publisher().await;
     context.set_as_active_publisher().await;
 
-    let data = Bytes::from(vec![1, 2, 3, 4, 5, 6, 7]);
+    let data = Bytes::from(vec![0x27, 2, 3, 4, 5, 6, 7]);
     let timestamp = RtmpTimestamp::new(5);
     context.client.publish_video(data.clone(), timestamp);
 
@@ -1379,38 +1379,6 @@ async fn watcher_receives_video_wrapped_in_flv_tag_denoting_keyframe() {
 }
 
 #[tokio::test]
-async fn watcher_does_not_receive_non_h264_video() {
-    let mut context = TestContextBuilder::new().into_watcher().await;
-    context.set_as_active_watcher().await;
-
-    let sent_data = Bytes::from(vec![1, 2, 3, 4]);
-    let sent_timestamp = RtmpTimestamp::new(5);
-
-    match context
-        .media_sender
-        .as_ref()
-        .unwrap()
-        .send(RtmpEndpointMediaMessage {
-            stream_key: Arc::new("key".to_string()),
-            data: RtmpEndpointMediaData::NewVideoData {
-                data: sent_data.clone(),
-                is_sequence_header: false,
-                is_keyframe: false,
-                timestamp: sent_timestamp,
-                composition_time_offset: 0,
-            },
-        }) {
-        Ok(_) => (),
-        Err(_) => panic!("Failed to send media message"),
-    }
-
-    let event = context.client.get_next_event().await;
-    if let Some(event) = event {
-        panic!("Expected no events, but got {:?}", event);
-    }
-}
-
-#[tokio::test]
 async fn aac_audio_has_flv_headers_added_for_sequence_header() {
     let mut context = TestContextBuilder::new().into_watcher().await;
     context.set_as_active_watcher().await;
@@ -1485,36 +1453,6 @@ async fn aac_audio_has_flv_headers_added_for_non_sequence_header() {
         }
 
         event => panic!("Unexpected event: {:?}", event),
-    }
-}
-
-#[tokio::test]
-async fn watcher_does_not_receives_unknown_audio_codec() {
-    let mut context = TestContextBuilder::new().into_watcher().await;
-    context.set_as_active_watcher().await;
-
-    let sent_data = Bytes::from(vec![1, 2, 3, 4]);
-    let sent_timestamp = RtmpTimestamp::new(5);
-
-    match context
-        .media_sender
-        .as_ref()
-        .unwrap()
-        .send(RtmpEndpointMediaMessage {
-            stream_key: Arc::new("key".to_string()),
-            data: RtmpEndpointMediaData::NewAudioData {
-                data: sent_data.clone(),
-                is_sequence_header: false,
-                timestamp: sent_timestamp,
-            },
-        }) {
-        Ok(_) => (),
-        Err(_) => panic!("Failed to send media message"),
-    };
-
-    let event = context.client.get_next_event().await;
-    if let Some(event) = event {
-        panic!("Expected no events, but got {:?}", event);
     }
 }
 

--- a/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
@@ -6,8 +6,6 @@ use crate::rtmp_server::{
     StreamKeyRegistration, ValidationResponse,
 };
 use bytes::Bytes;
-use mmids_core::codecs::VideoCodec;
-use mmids_core::codecs::VideoCodec::{Unknown, H264};
 use mmids_core::test_utils;
 use rml_rtmp::sessions::{ClientSessionEvent, StreamMetadata};
 use rml_rtmp::time::RtmpTimestamp;

--- a/mmids-rtmp/src/rtmp_server/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/mod.rs
@@ -23,6 +23,7 @@ use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::net::tcp::TcpSocketRequest;
 use mmids_core::net::{ConnectionId, IpAddress};
 use mmids_core::reactors::ReactorWorkflowUpdate;
+use mmids_core::workflows::metadata::{MetadataKey, MetadataValue};
 use mmids_core::workflows::MediaNotificationContent;
 use mmids_core::StreamId;
 use rml_rtmp::sessions::StreamMetadata;
@@ -31,7 +32,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
-use mmids_core::workflows::metadata::{MetadataKey, MetadataValue};
 
 /// Starts a new RTMP server endpoint, returning a channel that can be used to send notifications
 /// and requests to it.
@@ -353,7 +353,8 @@ impl RtmpEndpointMediaData {
                 }),
 
                 x if x == *VIDEO_CODEC_H264_AVC => {
-                    let is_keyframe = metadata.iter()
+                    let is_keyframe = metadata
+                        .iter()
                         .filter(|m| m.key() == is_keyframe_metadata_key)
                         .filter_map(|m| match m.value() {
                             MetadataValue::Bool(val) => Some(val),
@@ -362,7 +363,8 @@ impl RtmpEndpointMediaData {
                         .next()
                         .unwrap_or_default();
 
-                    let pts_offset = metadata.iter()
+                    let pts_offset = metadata
+                        .iter()
                         .filter(|m| m.key() == pts_offset_metadata_key)
                         .filter_map(|m| match m.value() {
                             MetadataValue::I32(val) => Some(val),

--- a/mmids-rtmp/src/rtmp_server/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/mod.rs
@@ -19,7 +19,7 @@ use crate::utils::hash_map_to_stream_metadata;
 use actor::actor_types::RtmpServerEndpointActor;
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
-use mmids_core::codecs::{VideoCodec, AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::net::tcp::TcpSocketRequest;
 use mmids_core::net::{ConnectionId, IpAddress};
 use mmids_core::reactors::ReactorWorkflowUpdate;

--- a/mmids-rtmp/src/rtmp_server/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/mod.rs
@@ -19,7 +19,7 @@ use crate::utils::hash_map_to_stream_metadata;
 use actor::actor_types::RtmpServerEndpointActor;
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
-use mmids_core::codecs::{AudioCodec, VideoCodec};
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, AudioCodec, VideoCodec};
 use mmids_core::net::tcp::TcpSocketRequest;
 use mmids_core::net::{ConnectionId, IpAddress};
 use mmids_core::reactors::ReactorWorkflowUpdate;
@@ -238,7 +238,6 @@ pub enum RtmpEndpointPublisherMessage {
     /// An RTMP publisher has sent in new audio data
     NewAudioData {
         publisher: ConnectionId,
-        codec: AudioCodec,
         is_sequence_header: bool,
         data: Bytes,
         timestamp: RtmpTimestamp,
@@ -304,20 +303,30 @@ pub enum RtmpEndpointMediaData {
     },
 
     NewAudioData {
-        codec: AudioCodec,
         is_sequence_header: bool,
         data: Bytes,
         timestamp: RtmpTimestamp,
     },
 }
 
+/// Failures that can occur when converting a `MediaNotificationContent` value to
+/// `RtmpEndpointMediaData`.
+#[derive(thiserror::Error, Debug)]
+pub enum MediaDataConversionFailure {
+    #[error("MediaNotificationContent variant cannot be converted")]
+    IncompatibleType,
+
+    #[error("The media payload type of '{0}' is not supported")]
+    UnsupportedPayloadType(Arc<String>)
+}
+
 impl TryFrom<MediaNotificationContent> for RtmpEndpointMediaData {
-    type Error = ();
+    type Error = MediaDataConversionFailure;
 
     fn try_from(value: MediaNotificationContent) -> Result<Self, Self::Error> {
         match value {
-            MediaNotificationContent::StreamDisconnected => Err(()),
-            MediaNotificationContent::NewIncomingStream { stream_name: _ } => Err(()),
+            MediaNotificationContent::StreamDisconnected => Err(MediaDataConversionFailure::IncompatibleType),
+            MediaNotificationContent::NewIncomingStream { stream_name: _ } => Err(MediaDataConversionFailure::IncompatibleType),
             MediaNotificationContent::Metadata { data } => {
                 Ok(RtmpEndpointMediaData::NewStreamMetaData {
                     metadata: hash_map_to_stream_metadata(&data),
@@ -339,19 +348,28 @@ impl TryFrom<MediaNotificationContent> for RtmpEndpointMediaData {
                 composition_time_offset: timestamp.pts_offset(),
             }),
 
-            MediaNotificationContent::Audio {
-                codec,
-                is_sequence_header,
+            MediaNotificationContent::MediaPayload {
+                payload_type,
+                media_type: _,
+                is_required_for_decoding,
                 timestamp,
                 data,
-            } => Ok(RtmpEndpointMediaData::NewAudioData {
-                data,
-                codec,
-                timestamp: RtmpTimestamp::new(timestamp.as_millis() as u32),
-                is_sequence_header,
-            }),
+                metadata: _,
+            } => {
+                match payload_type {
+                    x if x == *AUDIO_CODEC_AAC_RAW => {
+                        Ok(RtmpEndpointMediaData::NewAudioData {
+                            data,
+                            is_sequence_header: is_required_for_decoding,
+                            timestamp: RtmpTimestamp::new(timestamp.as_millis() as u32),
+                        })
+                    }
 
-            MediaNotificationContent::MediaPayload { .. } => unimplemented!(),
+                    other => {
+                        Err(MediaDataConversionFailure::UnsupportedPayloadType(other))
+                    }
+                }
+            },
         }
     }
 }

--- a/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
@@ -395,7 +395,7 @@ mod tests {
     use bytes::{Bytes, BytesMut};
     use futures::future::BoxFuture;
     use futures::stream::FuturesUnordered;
-    use mmids_core::codecs::{VideoCodec, AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
+    use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
     use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKeyMap, MetadataValue};
     use mmids_core::workflows::MediaType;
     use mmids_core::{test_utils, VideoTimestamp};

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
@@ -19,22 +19,22 @@ use mmids_core::workflows::steps::{
 };
 
 use crate::utils::video_timestamp_from_rtmp_data;
+use bytes::BytesMut;
 use futures::FutureExt;
+use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
 use mmids_core::reactors::manager::ReactorManagerRequest;
 use mmids_core::reactors::ReactorWorkflowUpdate;
+use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 use mmids_core::workflows::{MediaNotification, MediaNotificationContent, MediaType};
 use mmids_core::StreamId;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::iter;
+use std::sync::Arc;
 use std::time::Duration;
-use bytes::{BufMut, BytesMut};
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
 use tracing::{error, info};
-use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
-use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 
 pub const PORT_PROPERTY_NAME: &str = "port";
 pub const APP_PROPERTY_NAME: &str = "rtmp_app";
@@ -374,7 +374,10 @@ impl RtmpReceiverStep {
                             payload_type: AUDIO_CODEC_AAC_RAW.clone(),
                             media_type: MediaType::Audio,
                             timestamp: Duration::from_millis(timestamp.value as u64),
-                            metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut self.metadata_buffer),
+                            metadata: MediaPayloadMetadataCollection::new(
+                                iter::empty(),
+                                &mut self.metadata_buffer,
+                            ),
                             is_required_for_decoding: is_sequence_header,
                             data,
                         },

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
@@ -10,15 +10,12 @@ use crate::rtmp_server::{
     IpRestriction, RegistrationType, RtmpEndpointPublisherMessage, RtmpEndpointRequest,
     StreamKeyRegistration, ValidationResponse,
 };
-
 use mmids_core::net::{ConnectionId, IpAddress, IpAddressParseError};
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
 };
-
-use crate::utils::video_timestamp_from_rtmp_data;
 use bytes::BytesMut;
 use futures::FutureExt;
 use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
@@ -10,18 +10,20 @@ use crate::rtmp_server::{
     IpRestriction, RegistrationType, RtmpEndpointPublisherMessage, RtmpEndpointRequest,
     StreamKeyRegistration, ValidationResponse,
 };
+use bytes::BytesMut;
+use futures::FutureExt;
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::net::{ConnectionId, IpAddress, IpAddressParseError};
+use mmids_core::reactors::manager::ReactorManagerRequest;
+use mmids_core::reactors::ReactorWorkflowUpdate;
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
+use mmids_core::workflows::metadata::{
+    MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue,
+};
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
 };
-use bytes::BytesMut;
-use futures::FutureExt;
-use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
-use mmids_core::reactors::manager::ReactorManagerRequest;
-use mmids_core::reactors::ReactorWorkflowUpdate;
-use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKey, MetadataValue};
 use mmids_core::workflows::{MediaNotification, MediaNotificationContent, MediaType};
 use mmids_core::StreamId;
 use std::collections::HashMap;
@@ -354,13 +356,15 @@ impl RtmpReceiverStep {
                         self.is_keyframe_metadata_key,
                         MetadataValue::Bool(is_keyframe),
                         &mut self.metadata_buffer,
-                    ).unwrap(); // Should only happen if type mismatch occurs
+                    )
+                    .unwrap(); // Should only happen if type mismatch occurs
 
                     let pts_offset_metadata = MetadataEntry::new(
                         self.pts_offset_metadata_key,
                         MetadataValue::I32(composition_time_offset),
                         &mut self.metadata_buffer,
-                    ).unwrap(); // Should only happen if type mismatch occurs
+                    )
+                    .unwrap(); // Should only happen if type mismatch occurs
 
                     let metadata = MediaPayloadMetadataCollection::new(
                         [is_keyframe_metadata, pts_offset_metadata].into_iter(),

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
@@ -22,15 +22,19 @@ use crate::utils::video_timestamp_from_rtmp_data;
 use futures::FutureExt;
 use mmids_core::reactors::manager::ReactorManagerRequest;
 use mmids_core::reactors::ReactorWorkflowUpdate;
-use mmids_core::workflows::{MediaNotification, MediaNotificationContent};
+use mmids_core::workflows::{MediaNotification, MediaNotificationContent, MediaType};
 use mmids_core::StreamId;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::iter;
 use std::time::Duration;
+use bytes::{BufMut, BytesMut};
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
 use tracing::{error, info};
+use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
+use mmids_core::workflows::metadata::MediaPayloadMetadataCollection;
 
 pub const PORT_PROPERTY_NAME: &str = "port";
 pub const APP_PROPERTY_NAME: &str = "rtmp_app";
@@ -67,6 +71,7 @@ struct RtmpReceiverStep {
     status: StepStatus,
     connection_details: HashMap<ConnectionId, ConnectionDetails>,
     reactor_name: Option<Arc<String>>,
+    metadata_buffer: BytesMut,
 }
 
 impl StepFutureResult for FutureResult {}
@@ -206,6 +211,7 @@ impl StepGenerator for RtmpReceiverStepGenerator {
             } else {
                 StreamKeyRegistration::Exact(stream_key)
             },
+            metadata_buffer: BytesMut::new(),
         };
 
         let (sender, receiver) = unbounded_channel();
@@ -358,18 +364,19 @@ impl RtmpReceiverStep {
                 publisher,
                 is_sequence_header,
                 data,
-                codec,
                 timestamp,
             } => match self.connection_details.get(&publisher) {
                 None => (),
                 Some(connection) => {
                     outputs.media.push(MediaNotification {
                         stream_id: connection.stream_id.clone(),
-                        content: MediaNotificationContent::Audio {
-                            is_sequence_header,
-                            data,
-                            codec,
+                        content: MediaNotificationContent::MediaPayload {
+                            payload_type: AUDIO_CODEC_AAC_RAW.clone(),
+                            media_type: MediaType::Audio,
                             timestamp: Duration::from_millis(timestamp.value as u64),
+                            metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut self.metadata_buffer),
+                            is_required_for_decoding: is_sequence_header,
+                            data,
                         },
                     });
                 }

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
@@ -14,11 +14,15 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot::channel;
+use mmids_core::workflows::metadata::common_metadata::{get_is_keyframe_metadata_key, get_pts_offset_metadata_key};
+use mmids_core::workflows::metadata::MetadataKeyMap;
 
 struct TestContext {
     step_context: StepTestContext,
     rtmp_endpoint: UnboundedReceiver<RtmpEndpointRequest>,
     reactor_manager: UnboundedReceiver<ReactorManagerRequest>,
+    is_keyframe_metadata_key: MetadataKey,
+    pts_offset_metadata_key: MetadataKey,
 }
 
 struct DefinitionBuilder {
@@ -105,9 +109,15 @@ impl TestContext {
         let (reactor_sender, reactor_receiver) = unbounded_channel();
         let (rtmp_sender, rtmp_receiver) = unbounded_channel();
 
+        let mut metadata_key_map = MetadataKeyMap::new();
+        let is_keyframe_metadata_key = get_is_keyframe_metadata_key(&mut metadata_key_map);
+        let pts_offset_metadata_key = get_pts_offset_metadata_key(&mut metadata_key_map);
+
         let generator = RtmpReceiverStepGenerator {
             reactor_manager: reactor_sender,
             rtmp_endpoint_sender: rtmp_sender,
+            is_keyframe_metadata_key,
+            pts_offset_metadata_key,
         };
 
         let step_context = StepTestContext::new(Box::new(generator), definition)?;
@@ -116,6 +126,8 @@ impl TestContext {
             step_context,
             rtmp_endpoint: rtmp_receiver,
             reactor_manager: reactor_receiver,
+            is_keyframe_metadata_key,
+            pts_offset_metadata_key,
         })
     }
 
@@ -455,7 +467,6 @@ async fn video_notification_received_when_publisher_sends_video() {
         .send(RtmpEndpointPublisherMessage::NewVideoData {
             publisher: ConnectionId(Arc::new("connection".to_string())),
             data: Bytes::from(vec![1, 2, 3]),
-            codec: VideoCodec::H264,
             timestamp: RtmpTimestamp::new(5),
             is_keyframe: true,
             is_sequence_header: true,
@@ -475,19 +486,39 @@ async fn video_notification_received_when_publisher_sends_video() {
     assert_eq!(media.stream_id.0.as_str(), "test", "Unexpected stream id");
 
     match &media.content {
-        MediaNotificationContent::Video {
+        MediaNotificationContent::MediaPayload {
+            media_type,
+            payload_type,
             data,
             timestamp,
-            codec,
-            is_keyframe,
-            is_sequence_header,
+            is_required_for_decoding,
+            metadata
         } => {
-            assert_eq!(data, &vec![1, 2, 3], "Unexpected video data");
-            assert_eq!(timestamp.dts(), Duration::from_millis(5), "Unexpected dts");
-            assert_eq!(timestamp.pts_offset(), 123, "Unexpected pts offset");
-            assert_eq!(codec, &VideoCodec::H264, "Unexpected codec");
+            let is_keyframe = metadata.iter()
+                .filter(|m| m.key() == context.is_keyframe_metadata_key)
+                .filter_map(|m| match m.value() {
+                    MetadataValue::Bool(val) => Some(val),
+                    _ => None,
+                })
+                .next()
+                .unwrap_or_default();
+
+            let pts_offset = metadata.iter()
+                .filter(|m| m.key() == context.pts_offset_metadata_key)
+                .filter_map(|m| match m.value() {
+                    MetadataValue::I32(val) => Some(val),
+                    _ => None,
+                })
+                .next()
+                .unwrap_or_default();
+
+            assert_eq!(*media_type, MediaType::Video);
+            assert_eq!(*payload_type, *VIDEO_CODEC_H264_AVC, "Unexpected payload type");
+            assert_eq!(data, &vec![1, 2, 3], "Unexpected bytes");
+            assert_eq!(timestamp, &Duration::from_millis(5), "Unexpected dts");
+            assert!(is_required_for_decoding, "Expected is_required_for_decoding to be true");
             assert!(is_keyframe, "Expected is_keyframe to be true");
-            assert!(is_sequence_header, "Expected is_sequence_header to be true");
+            assert_eq!(pts_offset, 123, "Unexpected pts offset");
         }
 
         content => panic!("Unexpected media content: {:?}", content),
@@ -595,12 +626,13 @@ fn video_notification_passed_as_input_does_not_get_passed_as_output() {
         .step_context
         .assert_media_not_passed_through(MediaNotification {
             stream_id: StreamId(Arc::new("test".to_string())),
-            content: MediaNotificationContent::Video {
+            content: MediaNotificationContent::MediaPayload {
+                media_type: MediaType::Video,
+                payload_type: VIDEO_CODEC_H264_AVC.clone(),
                 data: Bytes::from(vec![1, 2]),
-                codec: VideoCodec::H264,
-                timestamp: VideoTimestamp::from_durations(Duration::new(0, 0), Duration::new(0, 0)),
-                is_keyframe: true,
-                is_sequence_header: true,
+                timestamp: Duration::new(0, 0),
+                is_required_for_decoding: true,
+                metadata: MediaPayloadMetadataCollection::new(iter::empty(), &mut BytesMut::new()),
             },
         });
 }

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
@@ -1,13 +1,12 @@
 use super::*;
 use anyhow::Result;
 use bytes::Bytes;
-use mmids_core::codecs::VideoCodec;
 use mmids_core::net::ConnectionId;
 use mmids_core::workflows::definitions::WorkflowStepType;
 use mmids_core::workflows::steps::StepTestContext;
 use mmids_core::workflows::MediaNotificationContent::StreamDisconnected;
 use mmids_core::workflows::{MediaNotification, MediaNotificationContent};
-use mmids_core::{test_utils, StreamId, VideoTimestamp};
+use mmids_core::{test_utils, StreamId};
 use rml_rtmp::sessions::StreamMetadata;
 use rml_rtmp::time::RtmpTimestamp;
 use std::collections::{HashMap, HashSet};

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
@@ -22,7 +22,7 @@ use crate::rtmp_server::{
 };
 use crate::utils::hash_map_to_stream_metadata;
 use futures::FutureExt;
-use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
+use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::net::{IpAddress, IpAddressParseError};
 use mmids_core::reactors::manager::ReactorManagerRequest;
 use mmids_core::reactors::ReactorWorkflowUpdate;
@@ -40,6 +40,7 @@ use thiserror::Error as ThisError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
 use tracing::{error, info, warn};
+use mmids_core::workflows::metadata::{MetadataKey, MetadataValue};
 
 pub const PORT_PROPERTY_NAME: &str = "port";
 pub const APP_PROPERTY_NAME: &str = "rtmp_app";
@@ -53,6 +54,8 @@ pub const REACTOR_NAME: &str = "reactor";
 pub struct RtmpWatchStepGenerator {
     rtmp_endpoint_sender: UnboundedSender<RtmpEndpointRequest>,
     reactor_manager: UnboundedSender<ReactorManagerRequest>,
+    is_keyframe_metadata_key: MetadataKey,
+    pts_offset_metadata_key: MetadataKey,
 }
 
 struct StreamWatchers {
@@ -74,6 +77,8 @@ struct RtmpWatchStep {
     media_channel: UnboundedSender<RtmpEndpointMediaMessage>,
     stream_id_to_name_map: HashMap<StreamId, Arc<String>>,
     stream_watchers: HashMap<Arc<String>, StreamWatchers>,
+    is_keyframe_metadata_key: MetadataKey,
+    pts_offset_metadata_key: MetadataKey,
 }
 
 impl StepFutureResult for RtmpWatchStepFutureResult {}
@@ -139,10 +144,14 @@ impl RtmpWatchStepGenerator {
     pub fn new(
         rtmp_endpoint_sender: UnboundedSender<RtmpEndpointRequest>,
         reactor_manager: UnboundedSender<ReactorManagerRequest>,
+        is_keyframe_metadata_key: MetadataKey,
+        pts_offset_metadata_key: MetadataKey,
     ) -> Self {
         RtmpWatchStepGenerator {
             rtmp_endpoint_sender,
             reactor_manager,
+            is_keyframe_metadata_key,
+            pts_offset_metadata_key,
         }
     }
 }
@@ -221,6 +230,8 @@ impl StepGenerator for RtmpWatchStepGenerator {
             stream_id_to_name_map: HashMap::new(),
             reactor_name,
             stream_watchers: HashMap::new(),
+            is_keyframe_metadata_key: self.is_keyframe_metadata_key,
+            pts_offset_metadata_key: self.pts_offset_metadata_key,
         };
 
         let (notification_sender, notification_receiver) = unbounded_channel();
@@ -419,39 +430,12 @@ impl RtmpWatchStep {
                     let _ = self.media_channel.send(rtmp_media);
                 }
 
-                MediaNotificationContent::Video {
-                    is_keyframe,
-                    is_sequence_header,
-                    codec,
-                    timestamp,
-                    data,
-                } => {
-                    let stream_key = match self.stream_id_to_name_map.get(&media.stream_id) {
-                        Some(key) => key,
-                        None => return,
-                    };
-
-                    let rtmp_media = RtmpEndpointMediaMessage {
-                        stream_key: stream_key.clone(),
-                        data: RtmpEndpointMediaData::NewVideoData {
-                            is_keyframe: *is_keyframe,
-                            is_sequence_header: *is_sequence_header,
-                            codec: *codec,
-                            data: data.clone(),
-                            timestamp: RtmpTimestamp::new(timestamp.dts().as_millis() as u32),
-                            composition_time_offset: timestamp.pts_offset(),
-                        },
-                    };
-
-                    let _ = self.media_channel.send(rtmp_media);
-                }
-
                 MediaNotificationContent::MediaPayload {
                     data,
                     payload_type,
                     media_type: _,
                     timestamp,
-                    metadata: _,
+                    metadata,
                     is_required_for_decoding,
                 } => {
                     let stream_key = match self.stream_id_to_name_map.get(&media.stream_id) {
@@ -465,6 +449,34 @@ impl RtmpWatchStep {
                             data: data.clone(),
                             timestamp: RtmpTimestamp::new(timestamp.as_millis() as u32),
                         },
+
+                        x if *x == *VIDEO_CODEC_H264_AVC => {
+                            let is_keyframe = metadata.iter()
+                                .filter(|m| m.key() == self.is_keyframe_metadata_key)
+                                .filter_map(|m| match m.value() {
+                                    MetadataValue::Bool(val) => Some(val),
+                                    _ => None,
+                                })
+                                .next()
+                                .unwrap_or_default();
+
+                            let pts_offset = metadata.iter()
+                                .filter(|m| m.key() == self.pts_offset_metadata_key)
+                                .filter_map(|m| match m.value() {
+                                    MetadataValue::I32(val) => Some(val),
+                                    _ => None,
+                                })
+                                .next()
+                                .unwrap_or_default();
+
+                            RtmpEndpointMediaData::NewVideoData {
+                                is_sequence_header: *is_required_for_decoding,
+                                is_keyframe,
+                                data: data.clone(),
+                                timestamp: RtmpTimestamp::new(timestamp.as_millis() as u32),
+                                composition_time_offset: pts_offset,
+                            }
+                        }
 
                         _ => return, // Payload type not supported by RTMP
                     };

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
@@ -22,6 +22,7 @@ use crate::rtmp_server::{
 };
 use crate::utils::hash_map_to_stream_metadata;
 use futures::FutureExt;
+use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
 use mmids_core::net::{IpAddress, IpAddressParseError};
 use mmids_core::reactors::manager::ReactorManagerRequest;
 use mmids_core::reactors::ReactorWorkflowUpdate;
@@ -39,7 +40,6 @@ use thiserror::Error as ThisError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
 use tracing::{error, info, warn};
-use mmids_core::codecs::AUDIO_CODEC_AAC_RAW;
 
 pub const PORT_PROPERTY_NAME: &str = "port";
 pub const APP_PROPERTY_NAME: &str = "rtmp_app";
@@ -460,12 +460,10 @@ impl RtmpWatchStep {
                     };
 
                     let rtmp_media_data = match payload_type {
-                        x if x == *AUDIO_CODEC_AAC_RAW => {
-                            RtmpEndpointMediaData::NewAudioData {
-                                is_sequence_header: *is_required_for_decoding,
-                                data: data.clone(),
-                                timestamp: RtmpTimestamp::new(timestamp.as_millis() as u32),
-                            }
+                        x if *x == *AUDIO_CODEC_AAC_RAW => RtmpEndpointMediaData::NewAudioData {
+                            is_sequence_header: *is_required_for_decoding,
+                            data: data.clone(),
+                            timestamp: RtmpTimestamp::new(timestamp.as_millis() as u32),
                         },
 
                         _ => return, // Payload type not supported by RTMP

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
@@ -27,6 +27,7 @@ use mmids_core::net::{IpAddress, IpAddressParseError};
 use mmids_core::reactors::manager::ReactorManagerRequest;
 use mmids_core::reactors::ReactorWorkflowUpdate;
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
+use mmids_core::workflows::metadata::{MetadataKey, MetadataValue};
 use mmids_core::workflows::steps::factory::StepGenerator;
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
@@ -40,7 +41,6 @@ use thiserror::Error as ThisError;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::Sender;
 use tracing::{error, info, warn};
-use mmids_core::workflows::metadata::{MetadataKey, MetadataValue};
 
 pub const PORT_PROPERTY_NAME: &str = "port";
 pub const APP_PROPERTY_NAME: &str = "rtmp_app";
@@ -451,7 +451,8 @@ impl RtmpWatchStep {
                         },
 
                         x if *x == *VIDEO_CODEC_H264_AVC => {
-                            let is_keyframe = metadata.iter()
+                            let is_keyframe = metadata
+                                .iter()
                                 .filter(|m| m.key() == self.is_keyframe_metadata_key)
                                 .filter_map(|m| match m.value() {
                                     MetadataValue::Bool(val) => Some(val),
@@ -460,7 +461,8 @@ impl RtmpWatchStep {
                                 .next()
                                 .unwrap_or_default();
 
-                            let pts_offset = metadata.iter()
+                            let pts_offset = metadata
+                                .iter()
                                 .filter(|m| m.key() == self.pts_offset_metadata_key)
                                 .filter_map(|m| match m.value() {
                                     MetadataValue::I32(val) => Some(val),

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
@@ -7,7 +7,12 @@ use bytes::{Bytes, BytesMut};
 use mmids_core::net::ConnectionId;
 use mmids_core::test_utils::expect_mpsc_response;
 use mmids_core::workflows::definitions::WorkflowStepType;
-use mmids_core::workflows::metadata::{MediaPayloadMetadataCollection, MetadataEntry, MetadataKeyMap};
+use mmids_core::workflows::metadata::common_metadata::{
+    get_is_keyframe_metadata_key, get_pts_offset_metadata_key,
+};
+use mmids_core::workflows::metadata::{
+    MediaPayloadMetadataCollection, MetadataEntry, MetadataKeyMap,
+};
 use mmids_core::workflows::steps::StepTestContext;
 use mmids_core::workflows::{MediaNotification, MediaNotificationContent, MediaType};
 use mmids_core::{test_utils, StreamId};
@@ -18,7 +23,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot::channel;
-use mmids_core::workflows::metadata::common_metadata::{get_is_keyframe_metadata_key, get_pts_offset_metadata_key};
 
 struct TestContext {
     step_context: StepTestContext,
@@ -373,13 +377,15 @@ async fn video_packet_sent_to_media_channel_after_new_stream_message_received() 
         context.is_keyframe_metadata_key,
         MetadataValue::Bool(true),
         &mut BytesMut::new(),
-    ).unwrap();
+    )
+    .unwrap();
 
     let pts_offset_metadata = MetadataEntry::new(
         context.pts_offset_metadata_key,
         MetadataValue::I32(10),
         &mut BytesMut::new(),
-    ).unwrap();
+    )
+    .unwrap();
 
     let metadata = MediaPayloadMetadataCollection::new(
         [is_keyframe_metadata, pts_offset_metadata].into_iter(),

--- a/validators/rtmp-server/src/main.rs
+++ b/validators/rtmp-server/src/main.rs
@@ -177,7 +177,6 @@ pub async fn main() {
                         data,
                         is_sequence_header,
                         timestamp,
-                        codec,
                     } => {
                         if announce_audio_data {
                             info!("Connection {} sent audio data", publisher);
@@ -198,7 +197,6 @@ pub async fn main() {
                                 data,
                                 is_sequence_header,
                                 timestamp,
-                                codec,
                             },
                         });
                     }

--- a/validators/rtmp-server/src/main.rs
+++ b/validators/rtmp-server/src/main.rs
@@ -143,7 +143,6 @@ pub async fn main() {
                         timestamp,
                         is_keyframe,
                         is_sequence_header,
-                        codec,
                         composition_time_offset,
                     } => {
                         if announce_video_data {
@@ -164,7 +163,6 @@ pub async fn main() {
                             data: RtmpEndpointMediaData::NewVideoData {
                                 data,
                                 timestamp,
-                                codec,
                                 is_sequence_header,
                                 is_keyframe,
                                 composition_time_offset,


### PR DESCRIPTION
The `MediaNotificationContent::Audio` and `MediaNotificationContent::Video` were previously depreciated in favor of `MediaNotificationContent::MediaPayload`.  

This PR fully removes them and replaces all usages with `MediaPayload`