### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/Validations.yml
+++ b/.github/workflows/Validations.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+  runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
       run: >
         sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base 
         gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav 
-        libgstrtspserver-1.0-dev libges-1.0-dev libunwind-14-dev
+        libgstrtspserver-1.0-dev libges-1.0-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/Validations.yml
+++ b/.github/workflows/Validations.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-  runs-on: ubuntu-18.04
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
       run: >
         sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base 
         gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav 
-        libgstrtspserver-1.0-dev libges-1.0-dev
+        libgstrtspserver-1.0-dev libges-1.0-dev 
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/Validations.yml
+++ b/.github/workflows/Validations.yml
@@ -22,7 +22,7 @@ jobs:
       run: >
         sudo apt-get install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base 
         gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav 
-        libgstrtspserver-1.0-dev libges-1.0-dev
+        libgstrtspserver-1.0-dev libges-1.0-dev libunwind-14-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Ubuntu 20.04 caused the gstreamer packages to fail to be installed due to dependency issues.  This fixes it by pinning CI to 18.04 for now.