### PR TITLE
Remove futures unordered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -121,9 +121,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cidr-utils"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355d5b5df67e58b523953d0c1a8d3d2c05f5af51f1332b0199b9c92263614ed0"
+checksum = "fdfa36f04861d39453affe1cf084ce2d6554021a84eb6f31ebdeafb6fb92a01c"
 dependencies = [
  "debug-helper",
  "num-bigint",
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"

--- a/mmids-core/src/actor_utils.rs
+++ b/mmids-core/src/actor_utils.rs
@@ -1,0 +1,40 @@
+//! Utilities useful for actor implementations.
+
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+
+/// Watches a tokio `UnboundedReceiver` for a message, and when a message is received sends that
+/// message to the actor via the `received_message` transformation function.
+pub fn notify_on_unbounded_recv<RecvMessage, ActorMessage>(
+    mut receiver: UnboundedReceiver<RecvMessage>,
+    actor_channel: UnboundedSender<ActorMessage>,
+    received_message: impl Fn(RecvMessage) -> ActorMessage + Send + 'static,
+    closed_message: impl FnOnce() -> ActorMessage + Send + 'static,
+) where
+    RecvMessage: Send + 'static,
+    ActorMessage: Send + 'static,
+{
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                received = receiver.recv() => {
+                    match received {
+                        Some(msg) => {
+                            let actor_msg = received_message(msg);
+                            let _ = actor_channel.send(actor_msg);
+                        }
+
+                        None => {
+                            let actor_msg = closed_message();
+                            let _ = actor_channel.send(actor_msg);
+                            break;
+                        }
+                    }
+                }
+
+                _ = actor_channel.closed() => {
+                    break;
+                }
+            }
+        }
+    });
+}

--- a/mmids-core/src/lib.rs
+++ b/mmids-core/src/lib.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::error;
 
+pub mod actor_utils;
 pub mod codecs;
 pub mod config;
 pub mod event_hub;

--- a/mmids-core/src/reactors/executors/mod.rs
+++ b/mmids-core/src/reactors/executors/mod.rs
@@ -32,7 +32,7 @@ pub trait ReactorExecutorGenerator {
 
 #[derive(Default)]
 pub struct ReactorExecutorFactory {
-    generators: HashMap<String, Box<dyn ReactorExecutorGenerator>>,
+    generators: HashMap<String, Box<dyn ReactorExecutorGenerator + Send>>,
 }
 
 #[derive(Error, Debug)]
@@ -71,7 +71,7 @@ impl ReactorExecutorFactory {
     pub fn register(
         &mut self,
         name: String,
-        generator: Box<dyn ReactorExecutorGenerator>,
+        generator: Box<dyn ReactorExecutorGenerator + Send>,
     ) -> Result<(), RegistrationError> {
         if self.generators.contains_key(&name) {
             return Err(RegistrationError::DuplicateName(name));

--- a/mmids-core/src/reactors/executors/mod.rs
+++ b/mmids-core/src/reactors/executors/mod.rs
@@ -27,7 +27,7 @@ pub trait ReactorExecutorGenerator {
     fn generate(
         &self,
         parameters: &HashMap<String, Option<String>>,
-    ) -> Result<Box<dyn ReactorExecutor>, Box<dyn std::error::Error + Sync + Send>>;
+    ) -> Result<Box<dyn ReactorExecutor + Send>, Box<dyn std::error::Error + Sync + Send>>;
 }
 
 #[derive(Default)]

--- a/mmids-core/src/reactors/executors/simple_http_executor.rs
+++ b/mmids-core/src/reactors/executors/simple_http_executor.rs
@@ -53,7 +53,7 @@ impl ReactorExecutorGenerator for SimpleHttpExecutorGenerator {
     fn generate(
         &self,
         parameters: &HashMap<String, Option<String>>,
-    ) -> Result<Box<dyn ReactorExecutor>, Box<dyn Error + Sync + Send>> {
+    ) -> Result<Box<dyn ReactorExecutor + Send>, Box<dyn Error + Sync + Send>> {
         let url = match parameters.get("url") {
             Some(Some(url)) => Arc::new(url.trim().to_string()),
             _ => return Err(Box::new(SimpleHttpExecutorError::UrlParameterNotProvided)),

--- a/mmids-core/src/reactors/manager.rs
+++ b/mmids-core/src/reactors/manager.rs
@@ -72,8 +72,6 @@ struct Actor {
     reactors: HashMap<Arc<String>, UnboundedSender<ReactorRequest>>,
 }
 
-unsafe impl Send for Actor {}
-
 impl Actor {
     fn new(
         executor_factory: ReactorExecutorFactory,

--- a/mmids-core/src/reactors/manager.rs
+++ b/mmids-core/src/reactors/manager.rs
@@ -481,7 +481,7 @@ mod tests {
         fn generate(
             &self,
             parameters: &HashMap<String, Option<String>>,
-        ) -> Result<Box<dyn ReactorExecutor>, Box<dyn Error + Sync + Send>> {
+        ) -> Result<Box<dyn ReactorExecutor + Send>, Box<dyn Error + Sync + Send>> {
             if parameters.contains_key("abc") {
                 Ok(Box::new(TestExecutor))
             } else {

--- a/mmids-core/src/reactors/manager.rs
+++ b/mmids-core/src/reactors/manager.rs
@@ -1,13 +1,11 @@
 //! The reactor manager creates new reactors and allows relaying requests to the correct reactor
 //! based on names.
 
+use crate::actor_utils::notify_on_unbounded_recv;
 use crate::event_hub::SubscriptionRequest;
 use crate::reactors::executors::{GenerationError, ReactorExecutorFactory};
 use crate::reactors::reactor::ReactorWorkflowUpdate;
 use crate::reactors::{start_reactor, ReactorDefinition, ReactorRequest};
-use futures::future::BoxFuture;
-use futures::stream::FuturesUnordered;
-use futures::{FutureExt, StreamExt};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
@@ -51,24 +49,26 @@ pub fn start_reactor_manager(
     event_hub_subscriber: UnboundedSender<SubscriptionRequest>,
 ) -> UnboundedSender<ReactorManagerRequest> {
     let (sender, receiver) = unbounded_channel();
-    let actor = Actor::new(executor_factory, receiver, event_hub_subscriber);
-    tokio::spawn(actor.run());
+    let (actor_sender, actor_receiver) = unbounded_channel();
+    let actor = Actor::new(
+        executor_factory,
+        receiver,
+        event_hub_subscriber,
+        actor_sender,
+    );
+    tokio::spawn(actor.run(actor_receiver));
 
     sender
 }
 
 enum FutureResult {
     AllConsumersGone,
-    RequestReceived(
-        ReactorManagerRequest,
-        UnboundedReceiver<ReactorManagerRequest>,
-    ),
+    RequestReceived(ReactorManagerRequest),
 }
 
 struct Actor {
     executor_factory: ReactorExecutorFactory,
     event_hub_subscriber: UnboundedSender<SubscriptionRequest>,
-    futures: FuturesUnordered<BoxFuture<'static, FutureResult>>,
     reactors: HashMap<Arc<String>, UnboundedSender<ReactorRequest>>,
 }
 
@@ -79,31 +79,34 @@ impl Actor {
         executor_factory: ReactorExecutorFactory,
         receiver: UnboundedReceiver<ReactorManagerRequest>,
         event_hub_subscriber: UnboundedSender<SubscriptionRequest>,
+        actor_sender: UnboundedSender<FutureResult>,
     ) -> Self {
-        let futures = FuturesUnordered::new();
-        futures.push(wait_for_request(receiver).boxed());
+        notify_on_unbounded_recv(
+            receiver,
+            actor_sender,
+            FutureResult::RequestReceived,
+            || FutureResult::AllConsumersGone,
+        );
 
         Actor {
             executor_factory,
             event_hub_subscriber,
-            futures,
             reactors: HashMap::new(),
         }
     }
 
     #[instrument(name = "Reactor Manager Execution", skip(self))]
-    async fn run(mut self) {
+    async fn run(mut self, mut receiver: UnboundedReceiver<FutureResult>) {
         info!("Starting reactor manager");
 
-        while let Some(result) = self.futures.next().await {
+        while let Some(result) = receiver.recv().await {
             match result {
                 FutureResult::AllConsumersGone => {
                     info!("All consumers gone");
                     break;
                 }
 
-                FutureResult::RequestReceived(request, receiver) => {
-                    self.futures.push(wait_for_request(receiver).boxed());
+                FutureResult::RequestReceived(request) => {
                     self.handle_request(request);
                 }
             }
@@ -199,13 +202,6 @@ impl Actor {
     }
 }
 
-async fn wait_for_request(mut receiver: UnboundedReceiver<ReactorManagerRequest>) -> FutureResult {
-    match receiver.recv().await {
-        Some(request) => FutureResult::RequestReceived(request, receiver),
-        None => FutureResult::AllConsumersGone,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,6 +210,8 @@ mod tests {
     };
     use crate::test_utils;
     use crate::workflows::definitions::WorkflowDefinition;
+    use futures::future::BoxFuture;
+    use futures::FutureExt;
     use std::error::Error;
     use std::time::Duration;
     use tokio::sync::oneshot::channel;

--- a/mmids-core/src/workflows/steps/mod.rs
+++ b/mmids-core/src/workflows/steps/mod.rs
@@ -10,7 +10,7 @@ use futures::future::BoxFuture;
 
 /// Represents the result of a future for a workflow step.  It is expected that the workflow step
 /// will downcast this result into a struct that it owns.
-pub trait StepFutureResult: Downcast {}
+pub trait StepFutureResult: Downcast + Send {}
 impl_downcast!(StepFutureResult);
 
 pub type FutureList = Vec<BoxFuture<'static, Box<dyn StepFutureResult>>>;

--- a/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
@@ -439,6 +439,7 @@ impl WorkflowStep for WorkflowForwarderStep {
 
     fn execute(&mut self, inputs: &mut StepInputs, outputs: &mut StepOutputs) {
         for notification in inputs.notifications.drain(..) {
+            let notification: Box<dyn StepFutureResult> = notification;
             let future_result = match notification.downcast::<FutureResult>() {
                 Ok(x) => *x,
                 Err(_) => {

--- a/mmids-gstreamer/Cargo.toml
+++ b/mmids-gstreamer/Cargo.toml
@@ -13,7 +13,7 @@ gstreamer = "0.18.3"
 gstreamer-app = "0.18.0"
 gstreamer-audio = "0.18.0"
 lazy_static = "1.4.0"
-thiserror = "1.0.30"
+thiserror = "1.0"
 tokio = "1.15"
 tracing = { version = "0.1", features = ["log"] }
 uuid = { version = "0.8.2", features = ["v4"]}

--- a/mmids-gstreamer/src/encoders/audio_avenc_aac.rs
+++ b/mmids-gstreamer/src/encoders/audio_avenc_aac.rs
@@ -30,7 +30,7 @@ impl AudioEncoderGenerator for AvencAacEncoderGenerator {
         pipeline: &Pipeline,
         parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> Result<Box<dyn AudioEncoder>> {
+    ) -> Result<Box<dyn AudioEncoder + Send>> {
         Ok(Box::new(AvencAacEncoder::new(
             media_sender,
             parameters,

--- a/mmids-gstreamer/src/encoders/audio_copy.rs
+++ b/mmids-gstreamer/src/encoders/audio_copy.rs
@@ -23,7 +23,7 @@ impl AudioEncoderGenerator for AudioCopyEncoderGenerator {
         pipeline: &Pipeline,
         _parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> Result<Box<dyn AudioEncoder>> {
+    ) -> Result<Box<dyn AudioEncoder + Send>> {
         Ok(Box::new(AudioCopyEncoder::new(media_sender, pipeline)?))
     }
 }

--- a/mmids-gstreamer/src/encoders/audio_drop.rs
+++ b/mmids-gstreamer/src/encoders/audio_drop.rs
@@ -17,7 +17,7 @@ impl AudioEncoderGenerator for AudioDropEncoderGenerator {
         _pipeline: &Pipeline,
         _parameters: &HashMap<String, Option<String>>,
         _media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> Result<Box<dyn AudioEncoder>> {
+    ) -> Result<Box<dyn AudioEncoder + Send>> {
         Ok(Box::new(AudioDropEncoder {}))
     }
 }

--- a/mmids-gstreamer/src/encoders/mod.rs
+++ b/mmids-gstreamer/src/encoders/mod.rs
@@ -98,8 +98,8 @@ pub trait AudioEncoderGenerator {
 /// invoked and the resulting encoder (or error) is returned.
 #[derive(Default)]
 pub struct EncoderFactory {
-    video_encoders: HashMap<String, Box<dyn VideoEncoderGenerator>>,
-    audio_encoders: HashMap<String, Box<dyn AudioEncoderGenerator>>,
+    video_encoders: HashMap<String, Box<dyn VideoEncoderGenerator + Send + Sync>>,
+    audio_encoders: HashMap<String, Box<dyn AudioEncoderGenerator + Send + Sync>>,
 }
 
 impl EncoderFactory {
@@ -112,7 +112,7 @@ impl EncoderFactory {
     pub fn register_video_encoder(
         &mut self,
         name: &str,
-        encoder_generator: Box<dyn VideoEncoderGenerator>,
+        encoder_generator: Box<dyn VideoEncoderGenerator + Send + Sync>,
     ) -> Result<(), EncoderFactoryRegistrationError> {
         if self.video_encoders.contains_key(name) {
             return Err(EncoderFactoryRegistrationError::DuplicateName(
@@ -129,7 +129,7 @@ impl EncoderFactory {
     pub fn register_audio_encoder(
         &mut self,
         name: &str,
-        encoder_generator: Box<dyn AudioEncoderGenerator>,
+        encoder_generator: Box<dyn AudioEncoderGenerator + Send + Sync>,
     ) -> Result<(), EncoderFactoryRegistrationError> {
         if self.audio_encoders.contains_key(name) {
             return Err(EncoderFactoryRegistrationError::DuplicateName(

--- a/mmids-gstreamer/src/encoders/mod.rs
+++ b/mmids-gstreamer/src/encoders/mod.rs
@@ -80,7 +80,7 @@ pub trait VideoEncoderGenerator {
         pipeline: &Pipeline,
         parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> anyhow::Result<Box<dyn VideoEncoder>>;
+    ) -> anyhow::Result<Box<dyn VideoEncoder + Send>>;
 }
 
 /// A type that can generate a new instance for a specific audio encoder.
@@ -90,7 +90,7 @@ pub trait AudioEncoderGenerator {
         pipeline: &Pipeline,
         parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> anyhow::Result<Box<dyn AudioEncoder>>;
+    ) -> anyhow::Result<Box<dyn AudioEncoder + Send>>;
 }
 
 /// Allows encoder generators to be registered and be referred to via a name that given at
@@ -150,7 +150,7 @@ impl EncoderFactory {
         pipeline: &Pipeline,
         parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> Result<Box<dyn VideoEncoder>, EncoderFactoryCreationError> {
+    ) -> Result<Box<dyn VideoEncoder + Send>, EncoderFactoryCreationError> {
         let generator = match self.video_encoders.get(name.as_str()) {
             Some(generator) => generator,
             None => return Err(EncoderFactoryCreationError::NoEncoderWithName(name)),
@@ -169,7 +169,7 @@ impl EncoderFactory {
         pipeline: &Pipeline,
         parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> Result<Box<dyn AudioEncoder>, EncoderFactoryCreationError> {
+    ) -> Result<Box<dyn AudioEncoder + Send>, EncoderFactoryCreationError> {
         let generator = match self.audio_encoders.get(name.as_str()) {
             Some(generator) => generator,
             None => return Err(EncoderFactoryCreationError::NoEncoderWithName(name)),

--- a/mmids-gstreamer/src/encoders/video_copy.rs
+++ b/mmids-gstreamer/src/encoders/video_copy.rs
@@ -29,7 +29,7 @@ impl VideoEncoderGenerator for VideoCopyEncoderGenerator {
         pipeline: &Pipeline,
         _parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> Result<Box<dyn VideoEncoder>> {
+    ) -> Result<Box<dyn VideoEncoder + Send>> {
         Ok(Box::new(VideoCopyEncoder::new(
             media_sender,
             pipeline,

--- a/mmids-gstreamer/src/encoders/video_drop.rs
+++ b/mmids-gstreamer/src/encoders/video_drop.rs
@@ -16,7 +16,7 @@ impl VideoEncoderGenerator for VideoDropEncoderGenerator {
         _pipeline: &Pipeline,
         _parameters: &HashMap<String, Option<String>>,
         _media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> anyhow::Result<Box<dyn VideoEncoder>> {
+    ) -> anyhow::Result<Box<dyn VideoEncoder + Send>> {
         Ok(Box::new(VideoDropEncoder {}))
     }
 }

--- a/mmids-gstreamer/src/encoders/video_x264.rs
+++ b/mmids-gstreamer/src/encoders/video_x264.rs
@@ -39,7 +39,7 @@ impl VideoEncoderGenerator for X264EncoderGenerator {
         pipeline: &Pipeline,
         parameters: &HashMap<String, Option<String>>,
         media_sender: UnboundedSender<MediaNotificationContent>,
-    ) -> Result<Box<dyn VideoEncoder>> {
+    ) -> Result<Box<dyn VideoEncoder + Send>> {
         Ok(Box::new(X264Encoder::new(
             media_sender,
             parameters,

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
@@ -155,9 +155,6 @@ struct EndpointActor {
     pts_offset_metadata_key: MetadataKey,
 }
 
-unsafe impl Send for EndpointActor {}
-unsafe impl Sync for EndpointActor {}
-
 impl EndpointActor {
     fn new(
         receiver: UnboundedReceiver<GstTranscoderRequest>,

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/mod.rs
@@ -361,7 +361,7 @@ impl EndpointActor {
 
 mod endpoint_futures {
     use crate::endpoints::gst_transcoder::transcoding_manager::TranscodeManagerRequest;
-    use crate::endpoints::gst_transcoder::{EndpointFuturesResult};
+    use crate::endpoints::gst_transcoder::EndpointFuturesResult;
     use tokio::sync::mpsc::UnboundedSender;
     use uuid::Uuid;
 

--- a/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
+++ b/mmids-gstreamer/src/endpoints/gst_transcoder/transcoding_manager.rs
@@ -280,7 +280,9 @@ fn notify_on_inbound_media(
                     }
                 }
 
-                _ = actor_sender.closed() => { }
+                _ = actor_sender.closed() => {
+                    break;
+                }
             }
         }
     });

--- a/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
@@ -1129,7 +1129,9 @@ mod internal_futures {
                         }
                     }
 
-                    _ = actor_sender.closed() => { }
+                    _ = actor_sender.closed() => {
+                        break;
+                    }
                 }
             }
         });

--- a/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
@@ -1037,7 +1037,7 @@ fn wrap_video_into_flv(
 ) -> Bytes {
     // Always assume h264
     let flv_tag = if is_keyframe { 0x17 } else { 0x27 };
-    let avc_type = if is_sequence_header { 0 } else { 1 };
+    let avc_type = u8::from(!is_sequence_header);
 
     let mut pts_value = Vec::new();
     pts_value
@@ -1079,7 +1079,7 @@ fn unwrap_audio_from_flv(mut data: Bytes) -> Result<UnwrappedAudio> {
 
 fn wrap_audio_into_flv(data: Bytes, is_sequence_header: bool) -> Bytes {
     let flv_tag = 0xaf; // Assume always aac
-    let packet_type = if is_sequence_header { 0 } else { 1 };
+    let packet_type = u8::from(!is_sequence_header);
     let mut wrapped = BytesMut::new();
     wrapped.put_u8(flv_tag);
     wrapped.put_u8(packet_type);

--- a/mmids-rtmp/src/rtmp_server/actor/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/mod.rs
@@ -1513,7 +1513,9 @@ mod internal_futures {
                         }
                     }
 
-                    _ = actor_sender.closed() => { }
+                    _ = actor_sender.closed() => {
+                        break;
+                    }
                 }
             }
         });
@@ -1572,7 +1574,9 @@ mod internal_futures {
                         }
                     }
 
-                    _ = actor_sender.closed() => { }
+                    _ = actor_sender.closed() => {
+                        break;
+                    }
                 }
             }
         });
@@ -1634,7 +1638,9 @@ mod internal_futures {
                         }
                     }
 
-                    _ = actor_sender.closed() => { }
+                    _ = actor_sender.closed() => {
+                        break;
+                    }
                 }
             }
         });

--- a/mmids-rtmp/src/rtmp_server/actor/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/mod.rs
@@ -8,14 +8,12 @@ use super::{
     RtmpEndpointMediaData, RtmpEndpointPublisherMessage, RtmpEndpointRequest, StreamKeyRegistration,
 };
 use crate::rtmp_server::actor::connection_handler::ConnectionResponse;
-use crate::rtmp_server::actor::internal_futures::wait_for_validation;
+use crate::rtmp_server::actor::internal_futures::notify_on_validation;
 use crate::rtmp_server::{
     IpRestriction, RegistrationType, RtmpEndpointWatcherNotification, ValidationResponse,
 };
 use actor_types::*;
 use connection_handler::{ConnectionRequest, RtmpServerConnectionHandler};
-use futures::future::{BoxFuture, FutureExt};
-use futures::StreamExt;
 use mmids_core::net::tcp::{TcpSocketRequest, TcpSocketResponse};
 use mmids_core::net::ConnectionId;
 use mmids_core::reactors::ReactorWorkflowUpdate;
@@ -40,25 +38,20 @@ struct RegisterListenerParams {
 }
 
 impl RtmpServerEndpointActor {
-    #[instrument(
-        name = "RtmpServer Endpoint Execution",
-        skip(self, endpoint_receiver, socket_request_sender)
-    )]
+    #[instrument(name = "RtmpServer Endpoint Execution", skip_all)]
     pub async fn run(
         mut self,
-        endpoint_receiver: UnboundedReceiver<RtmpEndpointRequest>,
+        mut actor_receiver: UnboundedReceiver<FutureResult>,
         socket_request_sender: UnboundedSender<TcpSocketRequest>,
     ) {
         info!("Starting RTMP server endpoint");
 
-        self.futures
-            .push(internal_futures::wait_for_endpoint_request(endpoint_receiver).boxed());
-
-        self.futures.push(
-            internal_futures::notify_on_socket_manager_gone(socket_request_sender.clone()).boxed(),
+        internal_futures::notify_on_socket_manager_gone(
+            socket_request_sender.clone(),
+            self.internal_actor.clone(),
         );
 
-        while let Some(result) = self.futures.next().await {
+        while let Some(result) = actor_receiver.recv().await {
             match result {
                 FutureResult::NoMoreEndpointRequesters => {
                     info!("No endpoint requesters exist");
@@ -70,10 +63,7 @@ impl RtmpServerEndpointActor {
                     break;
                 }
 
-                FutureResult::EndpointRequestReceived { request, receiver } => {
-                    self.futures
-                        .push(internal_futures::wait_for_endpoint_request(receiver).boxed());
-
+                FutureResult::EndpointRequestReceived(request) => {
                     self.handle_endpoint_request(request, socket_request_sender.clone());
                 }
 
@@ -93,31 +83,15 @@ impl RtmpServerEndpointActor {
                     self.remove_watcher_registration(port, app, stream_key);
                 }
 
-                FutureResult::SocketResponseReceived {
-                    port,
-                    response,
-                    receiver,
-                } => {
+                FutureResult::SocketResponseReceived { port, response } => {
                     self.handle_socket_response(port, response);
-                    self.futures
-                        .push(internal_futures::wait_for_socket_response(receiver, port).boxed());
                 }
 
                 FutureResult::ConnectionHandlerRequestReceived {
                     port,
                     connection_id,
                     request,
-                    receiver,
                 } => {
-                    self.futures.push(
-                        internal_futures::wait_for_connection_request(
-                            port,
-                            connection_id.clone(),
-                            receiver,
-                        )
-                        .boxed(),
-                    );
-
                     self.handle_connection_handler_request(port, connection_id, request);
                 }
 
@@ -137,20 +111,8 @@ impl RtmpServerEndpointActor {
                     port,
                     app,
                     stream_key,
-                    stream_key_registration,
                     data,
-                    receiver,
                 } => {
-                    self.futures.push(
-                        internal_futures::wait_for_watcher_media(
-                            receiver,
-                            port,
-                            app.clone(),
-                            stream_key_registration,
-                        )
-                        .boxed(),
-                    );
-
                     self.handle_watcher_media_received(port, app, stream_key, data);
                 }
 
@@ -222,18 +184,15 @@ impl RtmpServerEndpointActor {
                         let stream_key = stream_key.clone();
 
                         connection.received_registrant_approval = true;
-                        let future = handle_connection_request_publish(
+                        handle_connection_request_publish(
                             &connection_id,
                             port_map,
                             port,
                             rtmp_app,
                             stream_key,
                             Some(reactor_update_channel),
+                            self.internal_actor.clone(),
                         );
-
-                        if let Some(future) = future {
-                            self.futures.push(future);
-                        }
                     }
 
                     ConnectionState::WaitingForWatchValidation {
@@ -251,18 +210,15 @@ impl RtmpServerEndpointActor {
                         let stream_key = stream_key.clone();
 
                         connection.received_registrant_approval = true;
-                        let future = handle_connection_request_watch(
+                        handle_connection_request_watch(
                             connection_id,
                             port_map,
                             port,
                             rtmp_app,
                             stream_key,
                             Some(reactor_update_channel),
+                            self.internal_actor.clone(),
                         );
-
-                        if let Some(future) = future {
-                            self.futures.push(future);
-                        }
                     }
                 }
             }
@@ -508,8 +464,11 @@ impl RtmpServerEndpointActor {
             };
 
             let _ = params.socket_sender.send(request);
-            self.futures
-                .push(internal_futures::wait_for_socket_response(receiver, params.port).boxed());
+            internal_futures::notify_on_socket_response(
+                receiver,
+                params.port,
+                self.internal_actor.clone(),
+            );
         }
 
         let app_map = port_map
@@ -581,15 +540,13 @@ impl RtmpServerEndpointActor {
                     },
                 );
 
-                self.futures.push(
-                    internal_futures::wait_for_publisher_channel_closed(
-                        channel.clone(),
-                        params.port,
-                        params.rtmp_app,
-                        params.stream_key,
-                        cancel_sender,
-                    )
-                    .boxed(),
+                internal_futures::notify_on_publisher_channel_closed(
+                    channel.clone(),
+                    params.port,
+                    params.rtmp_app,
+                    params.stream_key,
+                    cancel_sender,
+                    self.internal_actor.clone(),
                 );
 
                 // If the port isn't in a listening mode, we don't want to claim that
@@ -658,25 +615,21 @@ impl RtmpServerEndpointActor {
                     },
                 );
 
-                self.futures.push(
-                    internal_futures::wait_for_watcher_notification_channel_closed(
-                        notification_channel.clone(),
-                        params.port,
-                        params.rtmp_app.clone(),
-                        params.stream_key.clone(),
-                        cancel_sender,
-                    )
-                    .boxed(),
+                internal_futures::wait_for_watcher_notification_channel_closed(
+                    notification_channel.clone(),
+                    params.port,
+                    params.rtmp_app.clone(),
+                    params.stream_key.clone(),
+                    cancel_sender,
+                    self.internal_actor.clone(),
                 );
 
-                self.futures.push(
-                    internal_futures::wait_for_watcher_media(
-                        media_channel,
-                        params.port,
-                        params.rtmp_app,
-                        params.stream_key,
-                    )
-                    .boxed(),
+                internal_futures::notify_on_watcher_media(
+                    media_channel,
+                    params.port,
+                    params.rtmp_app,
+                    params.stream_key,
+                    self.internal_actor.clone(),
                 );
 
                 // If the port isn't open yet, we don't want to claim registration was successful yet
@@ -776,13 +729,11 @@ impl RtmpServerEndpointActor {
                         },
                     );
 
-                    self.futures.push(
-                        internal_futures::wait_for_connection_request(
-                            port,
-                            connection_id,
-                            request_receiver,
-                        )
-                        .boxed(),
+                    internal_futures::notify_on_connection_request(
+                        port,
+                        connection_id,
+                        request_receiver,
+                        self.internal_actor.clone(),
                     );
                 }
 
@@ -828,36 +779,30 @@ impl RtmpServerEndpointActor {
                 rtmp_app,
                 stream_key,
             } => {
-                let future = handle_connection_request_publish(
+                handle_connection_request_publish(
                     &connection_id,
                     port_map,
                     port,
                     rtmp_app,
                     stream_key,
                     None,
+                    self.internal_actor.clone(),
                 );
-
-                if let Some(future) = future {
-                    self.futures.push(future);
-                }
             }
 
             ConnectionRequest::RequestWatch {
                 rtmp_app,
                 stream_key,
             } => {
-                let future = handle_connection_request_watch(
+                handle_connection_request_watch(
                     connection_id,
                     port_map,
                     port,
                     rtmp_app,
                     stream_key,
                     None,
+                    self.internal_actor.clone(),
                 );
-
-                if let Some(future) = future {
-                    self.futures.push(future);
-                }
             }
 
             ConnectionRequest::PublishFinished => {
@@ -1084,14 +1029,15 @@ fn handle_connection_request_watch(
     rtmp_app: Arc<String>,
     stream_key: Arc<String>,
     reactor_update_channel: Option<UnboundedReceiver<ReactorWorkflowUpdate>>,
-) -> Option<BoxFuture<'static, FutureResult>> {
+    actor_sender: UnboundedSender<FutureResult>,
+) {
     let connection = match port_map.connections.get_mut(&connection_id) {
         Some(x) => x,
         None => {
             warn!("Connection handler for connection {:?} sent request to watch on port {}, but that \
                 connection isn't being tracked.", connection_id, port);
 
-            return None;
+            return;
         }
     };
 
@@ -1109,7 +1055,7 @@ fn handle_connection_request_watch(
                 .response_channel
                 .send(ConnectionResponse::RequestRejected);
 
-            return None;
+            return;
         }
     };
 
@@ -1136,7 +1082,7 @@ fn handle_connection_request_watch(
                         .response_channel
                         .send(ConnectionResponse::RequestRejected);
 
-                    return None;
+                    return;
                 }
             }
         }
@@ -1156,7 +1102,7 @@ fn handle_connection_request_watch(
             .response_channel
             .send(ConnectionResponse::RequestRejected);
 
-        return None;
+        return;
     }
 
     if registrant.requires_registrant_approval && !connection.received_registrant_approval {
@@ -1180,9 +1126,9 @@ fn handle_connection_request_watch(
             },
         );
 
-        let future = wait_for_validation(port, connection_id.clone(), receiver).boxed();
+        notify_on_validation(port, connection_id.clone(), receiver, actor_sender);
 
-        return Some(future);
+        return;
     }
 
     let active_stream_key = application
@@ -1240,8 +1186,6 @@ fn handle_connection_request_watch(
         .send(ConnectionResponse::WatchRequestAccepted {
             channel: media_receiver,
         });
-
-    None
 }
 
 #[instrument(skip(port_map))]
@@ -1252,14 +1196,15 @@ fn handle_connection_request_publish(
     rtmp_app: Arc<String>,
     stream_key: Arc<String>,
     reactor_response_channel: Option<UnboundedReceiver<ReactorWorkflowUpdate>>,
-) -> Option<BoxFuture<'static, FutureResult>> {
+    actor_sender: UnboundedSender<FutureResult>,
+) {
     let connection = match port_map.connections.get_mut(connection_id) {
         Some(x) => x,
         None => {
             warn!("Connection handler for connection {:?} sent a request to publish on port {}, but that \
                 connection isn't being tracked.", connection_id, port);
 
-            return None;
+            return;
         }
     };
 
@@ -1274,7 +1219,7 @@ fn handle_connection_request_publish(
                 .response_channel
                 .send(ConnectionResponse::RequestRejected);
 
-            return None;
+            return;
         }
     };
 
@@ -1301,7 +1246,7 @@ fn handle_connection_request_publish(
                         .response_channel
                         .send(ConnectionResponse::RequestRejected);
 
-                    return None;
+                    return;
                 }
             }
         }
@@ -1330,7 +1275,7 @@ fn handle_connection_request_publish(
             .response_channel
             .send(ConnectionResponse::RequestRejected);
 
-        return None;
+        return;
     }
 
     if !is_ip_allowed(&connection.socket_address, &registrant.ip_restrictions) {
@@ -1347,7 +1292,7 @@ fn handle_connection_request_publish(
             .response_channel
             .send(ConnectionResponse::RequestRejected);
 
-        return None;
+        return;
     }
 
     if registrant.requires_registrant_approval && !connection.received_registrant_approval {
@@ -1371,9 +1316,9 @@ fn handle_connection_request_publish(
             },
         );
 
-        let future = wait_for_validation(port, connection_id.clone(), receiver).boxed();
+        notify_on_validation(port, connection_id.clone(), receiver, actor_sender);
 
-        return Some(future);
+        return;
     }
 
     // All good to publish
@@ -1403,8 +1348,6 @@ fn handle_connection_request_publish(
             stream_id,
             reactor_update_channel: reactor_response_channel,
         });
-
-    None
 }
 
 #[instrument(skip(port_map))]
@@ -1529,7 +1472,7 @@ fn clean_disconnected_connection(connection_id: ConnectionId, port_map: &mut Por
 
 mod internal_futures {
     use super::{
-        FutureResult, RtmpEndpointPublisherMessage, RtmpEndpointRequest, StreamKeyRegistration,
+        FutureResult, RtmpEndpointPublisherMessage, StreamKeyRegistration,
     };
     use crate::rtmp_server::actor::connection_handler::ConnectionRequest;
     use crate::rtmp_server::{
@@ -1541,136 +1484,202 @@ mod internal_futures {
     use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
     use tokio::sync::oneshot::Receiver;
 
-    pub(super) async fn wait_for_endpoint_request(
-        mut endpoint_receiver: UnboundedReceiver<RtmpEndpointRequest>,
-    ) -> FutureResult {
-        match endpoint_receiver.recv().await {
-            None => FutureResult::NoMoreEndpointRequesters,
-            Some(request) => FutureResult::EndpointRequestReceived {
-                request,
-                receiver: endpoint_receiver,
-            },
-        }
-    }
-
-    pub(super) async fn wait_for_socket_response(
+    pub(super) fn notify_on_socket_response(
         mut socket_receiver: UnboundedReceiver<TcpSocketResponse>,
         port: u16,
-    ) -> FutureResult {
-        match socket_receiver.recv().await {
-            None => FutureResult::PortGone { port },
-            Some(response) => FutureResult::SocketResponseReceived {
-                port,
-                response,
-                receiver: socket_receiver,
-            },
-        }
+        actor_sender: UnboundedSender<FutureResult>,
+    ) {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = socket_receiver.recv() => {
+                        match result {
+                            None => {
+                                let _ = actor_sender.send(FutureResult::PortGone {port});
+                            }
+
+                            Some(response) => {
+                                let _ = actor_sender.send(FutureResult::SocketResponseReceived {
+                                    port,
+                                    response
+                                });
+                            }
+                        }
+                    }
+
+                    _ = actor_sender.closed() => { }
+                }
+            }
+        });
     }
 
-    pub(super) async fn wait_for_publisher_channel_closed(
+    pub(super) fn notify_on_publisher_channel_closed(
         sender: UnboundedSender<RtmpEndpointPublisherMessage>,
         port: u16,
         app_name: Arc<String>,
         stream_key: StreamKeyRegistration,
         cancellation_receiver: UnboundedSender<()>,
-    ) -> FutureResult {
-        tokio::select! {
-            _ = sender.closed() => (),
-            _ = cancellation_receiver.closed() => (),
-        }
+        actor_sender: UnboundedSender<FutureResult>,
+    ) {
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = sender.closed() => (),
+                _ = cancellation_receiver.closed() => (),
+                _ = actor_sender.closed() => (),
+            }
 
-        FutureResult::PublishingRegistrantGone {
-            port,
-            app: app_name,
-            stream_key,
-        }
+            let _ = actor_sender.send(FutureResult::PublishingRegistrantGone {
+                port,
+                app: app_name,
+                stream_key,
+            });
+        });
     }
 
-    pub(super) async fn wait_for_connection_request(
+    pub(super) fn notify_on_connection_request(
         port: u16,
         connection_id: ConnectionId,
         mut receiver: UnboundedReceiver<ConnectionRequest>,
-    ) -> FutureResult {
-        match receiver.recv().await {
-            Some(request) => FutureResult::ConnectionHandlerRequestReceived {
-                port,
-                receiver,
-                connection_id,
-                request,
-            },
+        actor_sender: UnboundedSender<FutureResult>,
+    ) {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = receiver.recv() => {
+                        match result {
+                            Some(request) => {
+                                let _ = actor_sender.send(FutureResult::ConnectionHandlerRequestReceived {
+                                    port,
+                                    connection_id: connection_id.clone(),
+                                    request,
+                                });
+                            }
 
-            None => FutureResult::ConnectionHandlerGone {
-                port,
-                connection_id,
-            },
-        }
+                            None => {
+                                let _ = actor_sender.send(FutureResult::ConnectionHandlerGone {
+                                    port,
+                                    connection_id,
+                                });
+
+                                break;
+                            }
+                        }
+                    }
+
+                    _ = actor_sender.closed() => { }
+                }
+            }
+        });
     }
 
-    pub(super) async fn wait_for_watcher_notification_channel_closed(
+    pub(super) fn wait_for_watcher_notification_channel_closed(
         sender: UnboundedSender<RtmpEndpointWatcherNotification>,
         port: u16,
         app_name: Arc<String>,
         stream_key: StreamKeyRegistration,
         cancellation_token: UnboundedSender<()>,
-    ) -> FutureResult {
-        tokio::select! {
-            _ = sender.closed() => (),
-            _ = cancellation_token.closed() => (),
-        }
+        actor_sender: UnboundedSender<FutureResult>,
+    ) {
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = sender.closed() => (),
+                _ = cancellation_token.closed() => (),
+                _ = actor_sender.closed() => (),
+            }
 
-        FutureResult::WatcherRegistrantGone {
-            port,
-            app: app_name,
-            stream_key,
-        }
+            let _ = actor_sender.send(FutureResult::WatcherRegistrantGone {
+                port,
+                app: app_name,
+                stream_key,
+            });
+        });
     }
 
-    pub(super) async fn wait_for_watcher_media(
+    pub(super) fn notify_on_watcher_media(
         mut receiver: UnboundedReceiver<RtmpEndpointMediaMessage>,
         port: u16,
         app_name: Arc<String>,
         stream_key_registration: StreamKeyRegistration,
-    ) -> FutureResult {
-        match receiver.recv().await {
-            None => FutureResult::WatcherRegistrantGone {
-                port,
-                app: app_name,
-                stream_key: stream_key_registration,
-            },
-            Some(message) => FutureResult::WatcherMediaDataReceived {
-                port,
-                app: app_name,
-                stream_key: message.stream_key,
-                stream_key_registration,
-                data: message.data,
-                receiver,
-            },
-        }
+        actor_sender: UnboundedSender<FutureResult>,
+    ) {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = receiver.recv() => {
+                        match result {
+                            Some(message) => {
+                                let _ = actor_sender.send(FutureResult::WatcherMediaDataReceived {
+                                    port,
+                                    app: app_name.clone(),
+                                    stream_key: message.stream_key,
+                                    data: message.data,
+                                });
+                            }
+
+                            None => {
+                                let _ = actor_sender.send(FutureResult::WatcherRegistrantGone {
+                                    port,
+                                    app: app_name,
+                                    stream_key: stream_key_registration,
+                                });
+
+                                break;
+                            }
+                        }
+                    }
+
+                    _ = actor_sender.closed() => { }
+                }
+            }
+        });
     }
 
-    pub(super) async fn wait_for_validation(
+    pub(super) fn notify_on_validation(
         port: u16,
         connection_id: ConnectionId,
         receiver: Receiver<ValidationResponse>,
-    ) -> FutureResult {
-        match receiver.await {
-            Ok(response) => {
-                FutureResult::ValidationApprovalResponseReceived(port, connection_id, response)
+        actor_sender: UnboundedSender<FutureResult>,
+    ) {
+        tokio::spawn(async move {
+            tokio::select! {
+                result = receiver => {
+                    match result {
+                        Ok(response) => {
+                            let _ = actor_sender.send(FutureResult::ValidationApprovalResponseReceived(
+                                port,
+                                connection_id,
+                                response,
+                            ));
+                        }
+
+                        Err(_) => {
+                            let _ = actor_sender.send(FutureResult::ValidationApprovalResponseReceived(
+                                port,
+                                connection_id,
+                                ValidationResponse::Reject,
+                            ));
+                        }
+                    }
+                }
+
+                _ = actor_sender.closed() => { }
             }
-            Err(_) => FutureResult::ValidationApprovalResponseReceived(
-                port,
-                connection_id,
-                ValidationResponse::Reject,
-            ),
-        }
+        });
     }
 
-    pub(super) async fn notify_on_socket_manager_gone(
+    pub(super) fn notify_on_socket_manager_gone(
         sender: UnboundedSender<TcpSocketRequest>,
-    ) -> FutureResult {
-        sender.closed().await;
+        actor_sender: UnboundedSender<FutureResult>,
+    ) {
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = sender.closed() => {
+                    let _ = actor_sender.send(FutureResult::SocketManagerClosed);
+                }
 
-        FutureResult::SocketManagerClosed
+                _ = actor_sender.closed() => { }
+            }
+        });
     }
 }
 

--- a/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
@@ -1228,7 +1228,6 @@ async fn stream_becomes_inactive_when_only_watcher_stops_playback() {
 }
 
 #[tokio::test]
-#[ignore = "Need to figure out why this dead locks"]
 async fn stream_becomes_inactive_when_only_watcher_disconnects() {
     let mut context = TestContextBuilder::new().into_watcher().await;
     context.set_as_active_watcher().await;

--- a/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/tests/mod.rs
@@ -1228,6 +1228,7 @@ async fn stream_becomes_inactive_when_only_watcher_stops_playback() {
 }
 
 #[tokio::test]
+#[ignore = "Need to figure out why this dead locks"]
 async fn stream_becomes_inactive_when_only_watcher_disconnects() {
     let mut context = TestContextBuilder::new().into_watcher().await;
     context.set_as_active_watcher().await;


### PR DESCRIPTION
Previously, actors used a `FuturesUnordered` collection to maintain each type of asynchronous operation it needs to be notified about (e.g. receiving requests, notifications of channels to dependencies, etc...).  

Doing this requires each future to be boxed up (causing significant allocation load), causes potential quadratic wakeup poll times (especially in workflow runners that may be tracking a lot of futures at one time), and in general is a bit slower.

This pattern has been replaced with using a newly spawned tokio task to execute the future, and to send it's result to a private mpsc tokio channel for processing by the actor.  While this adds extra tokio tasks, it lowers heap allocations significantly and helps with latency, as Tokio's task scheduler is designed with this type of one task triggering another task type of workload.

A byproduct of this work was removing the unsafe send and sync implementations, which were there mostly due to inexperience at the time of originally trying to figure out my actor patterns.