### PR TITLE
Remove actor notification boilerplate

### DIFF
--- a/mmids-core/src/actor_utils.rs
+++ b/mmids-core/src/actor_utils.rs
@@ -38,3 +38,27 @@ pub fn notify_on_unbounded_recv<RecvMessage, ActorMessage>(
         }
     });
 }
+
+/// Watches a tokio `UnboundedSender` to be notified when the channel closes. Once the channel
+/// is closed it will send the specified message to the actor.
+pub fn notify_on_unbounded_closed<SenderMessage, ActorMessage>(
+    sender: UnboundedSender<SenderMessage>,
+    actor_channel: UnboundedSender<ActorMessage>,
+    closed_message: impl FnOnce() -> ActorMessage + Send + 'static,
+) where
+    SenderMessage: Send + 'static,
+    ActorMessage: Send + 'static,
+{
+    tokio::spawn(async move {
+        tokio::select! {
+            _ = sender.closed() => {
+                let actor_msg = closed_message();
+                let _ = actor_channel.send(actor_msg);
+            }
+
+            _ = actor_channel.closed() => {
+                // Can't send a message anywhere so just stop.
+            }
+        }
+    });
+}

--- a/mmids-core/src/actor_utils.rs
+++ b/mmids-core/src/actor_utils.rs
@@ -1,5 +1,6 @@
 //! Utilities useful for actor implementations.
 
+use std::future::Future;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 /// Watches a tokio `UnboundedReceiver` for a message, and when a message is received sends that
@@ -58,6 +59,29 @@ pub fn notify_on_unbounded_closed<SenderMessage, ActorMessage>(
 
             _ = actor_channel.closed() => {
                 // Can't send a message anywhere so just stop.
+            }
+        }
+    });
+}
+
+/// Allows notifying an actor when any arbitrary future is resolved.
+pub fn notify_on_future_completion<FutureResult, ActorMessage>(
+    future: impl Future<Output = FutureResult> + Send + 'static,
+    actor_channel: UnboundedSender<ActorMessage>,
+    completion_message: impl FnOnce(FutureResult) -> ActorMessage + Send + 'static,
+) where
+    FutureResult: Send + 'static,
+    ActorMessage: Send + 'static,
+{
+    tokio::spawn(async move {
+        tokio::select! {
+            result = future => {
+                let actor_msg = completion_message(result);
+                let _ = actor_channel.send(actor_msg);
+            }
+
+            _ = actor_channel.closed() => {
+                // Can't send a message so just end
             }
         }
     });

--- a/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/connection_handler.rs
@@ -3,7 +3,7 @@ use crate::rtmp_server::RtmpEndpointMediaData;
 use anyhow::{anyhow, Result};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use bytes::{BufMut, Bytes, BytesMut};
-use mmids_core::actor_utils::notify_on_unbounded_recv;
+use mmids_core::actor_utils::{notify_on_unbounded_closed, notify_on_unbounded_recv};
 use mmids_core::net::tcp::OutboundPacket;
 use mmids_core::net::ConnectionId;
 use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
@@ -162,9 +162,10 @@ impl RtmpServerConnectionHandler {
             || FutureResult::Disconnected,
         );
 
-        internal_futures::notify_on_outbound_bytes_closed(
+        notify_on_unbounded_closed(
             self.outgoing_byte_channel.clone(),
             self.internal_sender.clone(),
+            || FutureResult::Disconnected,
         );
 
         // Start the handshake process
@@ -1091,25 +1092,4 @@ fn wrap_audio_into_flv(data: Bytes, is_sequence_header: bool) -> Bytes {
     wrapped.extend(data);
 
     wrapped.freeze()
-}
-
-mod internal_futures {
-    use super::FutureResult;
-    use mmids_core::net::tcp::OutboundPacket;
-    use tokio::sync::mpsc::UnboundedSender;
-
-    pub(super) fn notify_on_outbound_bytes_closed(
-        sender: UnboundedSender<OutboundPacket>,
-        actor_sender: UnboundedSender<FutureResult>,
-    ) {
-        tokio::spawn(async move {
-            tokio::select! {
-                _ = sender.closed() => {
-                    let _ = actor_sender.send(FutureResult::Disconnected);
-                }
-
-                _ = actor_sender.closed() => { }
-            }
-        });
-    }
 }

--- a/mmids-rtmp/src/rtmp_server/actor/mod.rs
+++ b/mmids-rtmp/src/rtmp_server/actor/mod.rs
@@ -562,7 +562,7 @@ impl RtmpServerEndpointActor {
                             port: params.port,
                             app: params.rtmp_app,
                             stream_key: params.stream_key,
-                        }
+                        },
                     )
                 }
 


### PR DESCRIPTION
A lot of actors were spinning up a bunch of tokio tasks + tokio selects just to facilitate notifications back to the actor.  This PR consolidates a lot of the boilerplate into actor utility functions that are easier to manage and harder to cause issues (such as forgetting to break out of a loop on an actor closing).