### PR TITLE
Resolve CI warnings

### DIFF
--- a/.github/workflows/Validations.yml
+++ b/.github/workflows/Validations.yml
@@ -12,10 +12,10 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: apt-get update
       run: sudo apt-get update
     - name: Install GStreamer


### PR DESCRIPTION
Ubuntu 18.04 is being depreciated and the v2 of the checkout action uses a depreciated version of node.js.