### PR TITLE
Workflow steps should send futures via channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "rml_rtmp",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.4",
  "tracing",
  "uuid 1.2.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
+ "tokio-util 0.7.4",
  "tracing",
  "uuid 1.2.2",
 ]
@@ -1578,9 +1579,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1593,7 +1594,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/mmids-app/Cargo.toml
+++ b/mmids-app/Cargo.toml
@@ -12,7 +12,7 @@ mmids-rtmp = { path = "../mmids-rtmp" }
 async-trait = "0.1.51"
 hyper = { version = "0.14", features = ["full"] }
 native-tls = "0.2"
-tokio = { version = "1.21", features = ["sync", "rt-multi-thread", "signal"] }
+tokio = { version = "1.24", features = ["sync", "rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-appender = "0.2.0"
 tracing-futures = "0.2.5"

--- a/mmids-core/Cargo.toml
+++ b/mmids-core/Cargo.toml
@@ -29,8 +29,9 @@ pest_derive = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.21", features = ["sync", "rt-multi-thread", "macros"] }
+tokio = { version = "1.24", features = ["sync", "rt-multi-thread", "macros"] }
 tokio-native-tls = "0.3"
+tokio-util = "0.7"
 tracing = { version = "0.1", features = ["log"] }
 uuid = { version = "1.2", features = ["v4"] }
 

--- a/mmids-core/src/http_api/handlers/get_workflow_details.rs
+++ b/mmids-core/src/http_api/handlers/get_workflow_details.rs
@@ -154,7 +154,7 @@ impl From<WorkflowState> for WorkflowStateResponse {
 impl From<WorkflowStepState> for WorkflowStepStateResponse {
     fn from(step_state: WorkflowStepState) -> Self {
         WorkflowStepStateResponse {
-            step_id: step_state.definition.get_id().to_string(),
+            step_id: step_state.definition.get_id().0.to_string(),
             step_type: step_state.definition.step_type.0,
             parameters: step_state.definition.parameters,
             status: match step_state.status {

--- a/mmids-core/src/workflows/definitions.rs
+++ b/mmids-core/src/workflows/definitions.rs
@@ -1,12 +1,18 @@
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 /// Identifier representing the type of the workflow step being defined
 #[derive(Clone, Hash, Debug, Eq, PartialEq)]
 pub struct WorkflowStepType(pub String);
+
+/// Identifies a specific workflow step. Two steps with the same set of parameters and values will
+/// always produce the same id within a single run of the the application, but the identifiers are
+/// not guaranteed to be consistent across application runs.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct WorkflowStepId(pub u64);
 
 /// The definition of a workflow step and any parameters it may be using
 #[derive(Clone, Debug)]
@@ -30,14 +36,11 @@ impl std::fmt::Display for WorkflowStepType {
 }
 
 impl WorkflowStepDefinition {
-    /// Gets an identifier for the workflow step that's based on the step's parameters.  Two
-    /// steps with the same set of parameters and values will always produce the same id within
-    /// a single run of the the application, but the identifiers are not guaranteed to be consistent
-    /// across application runs.
-    pub fn get_id(&self) -> u64 {
+    /// Gets an identifier for the workflow step that's based on the step's parameters.
+    pub fn get_id(&self) -> WorkflowStepId {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
-        hasher.finish()
+        WorkflowStepId(hasher.finish())
     }
 }
 
@@ -51,6 +54,12 @@ impl Hash for WorkflowStepDefinition {
             key.hash(state);
             self.parameters.get(key).hash(state);
         }
+    }
+}
+
+impl Display for WorkflowStepId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/mmids-core/src/workflows/runner/test_context.rs
+++ b/mmids-core/src/workflows/runner/test_context.rs
@@ -1,4 +1,6 @@
-use crate::workflows::definitions::{WorkflowDefinition, WorkflowStepDefinition, WorkflowStepType};
+use crate::workflows::definitions::{
+    WorkflowDefinition, WorkflowStepDefinition, WorkflowStepId, WorkflowStepType,
+};
 use crate::workflows::runner::test_steps::{TestInputStepGenerator, TestOutputStepGenerator};
 use crate::workflows::steps::factory::WorkflowStepFactory;
 use crate::workflows::steps::StepStatus;
@@ -17,8 +19,8 @@ pub struct TestContext {
     pub media_receiver: UnboundedReceiver<MediaNotification>,
     pub input_status: Sender<StepStatus>,
     pub output_status: Sender<StepStatus>,
-    pub input_step_id: u64,
-    pub output_step_id: u64,
+    pub input_step_id: WorkflowStepId,
+    pub output_step_id: WorkflowStepId,
 }
 
 impl TestContext {

--- a/mmids-core/src/workflows/runner/tests.rs
+++ b/mmids-core/src/workflows/runner/tests.rs
@@ -191,7 +191,7 @@ async fn workflow_in_error_state_if_any_step_goes_to_error_state() {
             failed_step_id,
         } => {
             assert_eq!(
-                failed_step_id, context.output_step_id,
+                failed_step_id, context.output_step_id.0,
                 "Unexpected failed step id"
             );
         }
@@ -500,7 +500,7 @@ async fn workflow_in_error_state_if_factory_cant_find_step() {
             message: _,
             failed_step_id,
         } => {
-            assert_eq!(failed_step_id, step_id, "Unexpected failed step id");
+            assert_eq!(failed_step_id, step_id.0, "Unexpected failed step id");
         }
 
         status => panic!("Unexpected workflow status: {:?}", status),
@@ -563,7 +563,7 @@ async fn workflow_in_error_state_if_updated_steps_arent_registered_with_factory(
             message: _,
             failed_step_id,
         } => {
-            assert_eq!(failed_step_id, step1_id, "Unexpected failed step id");
+            assert_eq!(failed_step_id, step1_id.0, "Unexpected failed step id");
         }
 
         status => panic!("Unexpected workflow status: {:?}", status),

--- a/mmids-core/src/workflows/steps/futures_channel.rs
+++ b/mmids-core/src/workflows/steps/futures_channel.rs
@@ -2,4 +2,53 @@
 //! to execute a future and send the results of those futures back to the correct workflow runner
 //! with minimal allocations.
 
-pub struct WorkflowStepFuturesChannel {}
+use crate::workflows::definitions::WorkflowStepId;
+use crate::workflows::steps::{StepFutureResult, WorkflowStep};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+/// An channel which can be used by workflow steps to send future completion results to the
+/// workflow runner.
+#[derive(Clone)]
+pub struct WorkflowStepFuturesChannel {
+    step_id: WorkflowStepId,
+    sender: UnboundedSender<FuturesChannelResult>,
+}
+
+/// The type of information that's returned to the workflow upon a future's completion
+pub(crate) struct FuturesChannelResult {
+    pub step_id: WorkflowStepId,
+    pub result: Box<dyn StepFutureResult>,
+}
+
+/// Creates a new workflow step futures channel sender and receiver
+pub(crate) fn create_channel(
+    step_id: WorkflowStepId,
+) -> (
+    WorkflowStepFuturesChannel,
+    UnboundedReceiver<FuturesChannelResult>,
+) {
+    let (sender, receiver) = unbounded_channel();
+
+    let sender = WorkflowStepFuturesChannel { step_id, sender };
+    (sender, receiver)
+}
+
+impl WorkflowStepFuturesChannel {
+    /// Sends the workflow step's future result over the channel. Returns an error if the channel
+    /// is closed.
+    pub fn send(&self, message: impl StepFutureResult) -> Result<(), Box<dyn StepFutureResult>> {
+        let message = FuturesChannelResult {
+            step_id: self.step_id,
+            result: Box::new(message),
+        };
+
+        self.sender
+            .send(message)
+            .map_err(|e| e.0.result)
+    }
+
+    /// Completes when the channel is closed due to there being no receiver
+    pub async fn closed(&self) {
+        self.sender.closed().await
+    }
+}

--- a/mmids-core/src/workflows/steps/futures_channel.rs
+++ b/mmids-core/src/workflows/steps/futures_channel.rs
@@ -1,0 +1,5 @@
+//! This module provides abstractions over MPSC channels, which make it easy for workflow steps
+//! to execute a future and send the results of those futures back to the correct workflow runner
+//! with minimal allocations.
+
+pub struct WorkflowStepFuturesChannel {}

--- a/mmids-core/src/workflows/steps/futures_channel.rs
+++ b/mmids-core/src/workflows/steps/futures_channel.rs
@@ -17,13 +17,13 @@ pub struct WorkflowStepFuturesChannel {
 }
 
 /// The type of information that's returned to the workflow upon a future's completion
-pub(crate) struct FuturesChannelResult {
+pub struct FuturesChannelResult {
     pub step_id: WorkflowStepId,
     pub result: Box<dyn StepFutureResult>,
 }
 
 impl WorkflowStepFuturesChannel {
-    pub(crate) fn new(
+    pub fn new(
         step_id: WorkflowStepId,
         sender: UnboundedSender<FuturesChannelResult>,
     ) -> Self {

--- a/mmids-core/src/workflows/steps/futures_channel.rs
+++ b/mmids-core/src/workflows/steps/futures_channel.rs
@@ -23,10 +23,7 @@ pub struct FuturesChannelResult {
 }
 
 impl WorkflowStepFuturesChannel {
-    pub fn new(
-        step_id: WorkflowStepId,
-        sender: UnboundedSender<FuturesChannelResult>,
-    ) -> Self {
+    pub fn new(step_id: WorkflowStepId, sender: UnboundedSender<FuturesChannelResult>) -> Self {
         WorkflowStepFuturesChannel { step_id, sender }
     }
 

--- a/mmids-core/src/workflows/steps/mod.rs
+++ b/mmids-core/src/workflows/steps/mod.rs
@@ -107,12 +107,16 @@ pub trait WorkflowStep {
 
 #[cfg(feature = "test-utils")]
 use crate::workflows::steps::factory::StepGenerator;
-use crate::workflows::steps::futures_channel::{FuturesChannelResult, WorkflowStepFuturesChannel};
+#[cfg(feature = "test-utils")]
+use crate::workflows::steps::futures_channel::FuturesChannelResult;
+use crate::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 #[cfg(feature = "test-utils")]
 use anyhow::{anyhow, Result};
 #[cfg(feature = "test-utils")]
 use std::time::Duration;
+#[cfg(feature = "test-utils")]
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+#[cfg(feature = "test-utils")]
 use tokio::time::timeout;
 
 #[cfg(feature = "test-utils")]

--- a/mmids-core/src/workflows/steps/mod.rs
+++ b/mmids-core/src/workflows/steps/mod.rs
@@ -1,6 +1,7 @@
 //! Workflow steps are individual actions that can be taken on media as part of a media pipeline.
 
 pub mod factory;
+pub mod futures_channel;
 pub mod workflow_forwarder;
 
 use super::MediaNotification;

--- a/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
@@ -623,7 +623,7 @@ fn notify_on_reactor_update(
     futures_channel: &WorkflowStepFuturesChannel,
 ) {
     let recv_stream_id = stream_id.clone();
-    let cancelled_stream_id = stream_id.clone();
+    let cancelled_stream_id = stream_id;
     futures_channel.send_on_unbounded_recv_cancellable(
         update_receiver,
         cancellation_token,

--- a/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
@@ -90,7 +90,7 @@ impl TestContext {
             })
             .expect("Failed to send workflow started event");
 
-        let result = test_utils::expect_future_resolved(&mut self.step_context.futures).await;
+        let result = self.step_context.expect_future_resolved().await;
         self.step_context.execute_notification(result).await;
     }
 
@@ -101,7 +101,7 @@ impl TestContext {
             })
             .expect("Failed to send workflow ended event");
 
-        let result = test_utils::expect_future_resolved(&mut self.step_context.futures).await;
+        let result = self.step_context.expect_future_resolved().await;
         self.step_context.execute_notification(result).await;
     }
 }

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
+use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 
 pub struct FfmpegHandler {
     ffmpeg_endpoint: UnboundedSender<FfmpegEndpointRequest>,
@@ -114,7 +115,7 @@ impl FfmpegHandler {
 }
 
 impl ExternalStreamHandler for FfmpegHandler {
-    fn prepare_stream(&mut self, stream_name: &str, outputs: &mut StepOutputs) {
+    fn prepare_stream(&mut self, stream_name: &str, futures_channel: &WorkflowStepFuturesChannel) {
         if let FfmpegHandlerStatus::Inactive = &self.status {
             let parameters = self
                 .param_generator
@@ -182,7 +183,7 @@ impl ExternalStreamHandler for FfmpegHandler {
 async fn wait_for_ffmpeg_notification(
     stream_id: StreamId,
     mut receiver: UnboundedReceiver<FfmpegEndpointNotification>,
-) -> Box<dyn StepFutureResult> {
+) {
     let result = match receiver.recv().await {
         Some(msg) => FutureResult::NotificationReceived(msg, receiver),
 

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
@@ -1,5 +1,6 @@
 use crate::endpoint::{FfmpegEndpointNotification, FfmpegEndpointRequest, FfmpegParams};
 use futures::FutureExt;
+use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 use mmids_core::workflows::steps::{StepFutureResult, StepOutputs};
 use mmids_core::StreamId;
 use mmids_rtmp::workflow_steps::external_stream_handler::{
@@ -10,7 +11,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
-use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 
 pub struct FfmpegHandler {
     ffmpeg_endpoint: UnboundedSender<FfmpegEndpointRequest>,

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
@@ -182,11 +182,11 @@ impl ExternalStreamHandler for FfmpegHandler {
 
 #[cfg(test)]
 mod tests {
-    use tokio::sync::mpsc::UnboundedReceiver;
-    use mmids_core::workflows::definitions::WorkflowStepId;
-    use mmids_core::workflows::steps::futures_channel::FuturesChannelResult;
     use super::*;
     use crate::endpoint::{AudioTranscodeParams, TargetParams, VideoTranscodeParams};
+    use mmids_core::workflows::definitions::WorkflowStepId;
+    use mmids_core::workflows::steps::futures_channel::FuturesChannelResult;
+    use tokio::sync::mpsc::UnboundedReceiver;
 
     struct TestParamGenerator;
     impl FfmpegParameterGenerator for TestParamGenerator {
@@ -221,10 +221,8 @@ mod tests {
             };
 
             let (futures_sender, futures_receiver) = unbounded_channel();
-            let futures_channel = WorkflowStepFuturesChannel::new(
-                WorkflowStepId(234),
-                futures_sender,
-            );
+            let futures_channel =
+                WorkflowStepFuturesChannel::new(WorkflowStepId(234), futures_sender);
 
             let handler = generator.generate(StreamId(Arc::new("test".to_string())));
             TestContext {
@@ -240,7 +238,9 @@ mod tests {
     async fn prepare_stream_sends_start_ffmpeg_request() {
         let mut context = TestContext::new();
 
-        context.handler.prepare_stream("name", &context.step_futures_channel);
+        context
+            .handler
+            .prepare_stream("name", &context.step_futures_channel);
 
         match context.ffmpeg.try_recv() {
             Ok(FfmpegEndpointRequest::StartFfmpeg {
@@ -259,7 +259,9 @@ mod tests {
     async fn stop_ffmpeg_sent_when_stop_stream_called() {
         let mut context = TestContext::new();
 
-        context.handler.prepare_stream("name", &context.step_futures_channel);
+        context
+            .handler
+            .prepare_stream("name", &context.step_futures_channel);
         let _ = context.ffmpeg.try_recv();
         context.handler.stop_stream();
 

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
@@ -10,7 +10,6 @@ use crate::endpoint::{
     TargetParams, VideoTranscodeParams,
 };
 use bytes::BytesMut;
-use futures::FutureExt;
 use mmids_core::codecs::{AUDIO_CODEC_AAC_RAW, VIDEO_CODEC_H264_AVC};
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
 use mmids_core::workflows::metadata::{
@@ -30,9 +29,10 @@ use std::iter;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tracing::{error, info};
 use uuid::Uuid;
+use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 
 pub const LOCATION: &str = "location";
 pub const STREAM_NAME: &str = "stream_name";
@@ -63,14 +63,8 @@ struct FfmpegPullStep {
 enum FutureResult {
     RtmpEndpointGone,
     FfmpegEndpointGone,
-    RtmpEndpointResponseReceived(
-        RtmpEndpointPublisherMessage,
-        UnboundedReceiver<RtmpEndpointPublisherMessage>,
-    ),
-    FfmpegNotificationReceived(
-        FfmpegEndpointNotification,
-        UnboundedReceiver<FfmpegEndpointNotification>,
-    ),
+    RtmpEndpointResponseReceived(RtmpEndpointPublisherMessage),
+    FfmpegNotificationReceived(FfmpegEndpointNotification),
 }
 
 impl StepFutureResult for FutureResult {}
@@ -101,7 +95,11 @@ impl FfmpegPullStepGenerator {
 }
 
 impl StepGenerator for FfmpegPullStepGenerator {
-    fn generate(&self, definition: WorkflowStepDefinition) -> StepCreationResult {
+    fn generate(
+        &self,
+        definition: WorkflowStepDefinition,
+        futures_channel: WorkflowStepFuturesChannel,
+    ) -> StepCreationResult {
         let location = match definition.parameters.get(LOCATION) {
             Some(Some(value)) => value.clone(),
             _ => return Err(Box::new(StepStartupError::NoLocationSpecified)),
@@ -141,18 +139,32 @@ impl StepGenerator for FfmpegPullStepGenerator {
                 requires_registrant_approval: false,
             });
 
-        let futures = vec![
-            notify_rtmp_endpoint_gone(self.rtmp_endpoint.clone()).boxed(),
-            notify_ffmpeg_endpoint_gone(self.ffmpeg_endpoint.clone()).boxed(),
-            wait_for_rtmp_notification(receiver).boxed(),
-        ];
 
-        Ok((Box::new(step), futures))
+        let ffmpeg_endpoint = self.ffmpeg_endpoint.clone();
+        futures_channel.send_on_future_completion(
+            async move {
+                ffmpeg_endpoint.closed().await;
+                FutureResult::FfmpegEndpointGone
+            }
+        );
+
+        futures_channel.send_on_unbounded_recv(
+            receiver,
+            |response| FutureResult::RtmpEndpointResponseReceived(response),
+            || FutureResult::RtmpEndpointGone,
+        );
+
+        Ok(Box::new(step))
     }
 }
 
 impl FfmpegPullStep {
-    fn handle_resolved_future(&mut self, result: FutureResult, outputs: &mut StepOutputs) {
+    fn handle_resolved_future(
+        &mut self,
+        result: FutureResult,
+        outputs: &mut StepOutputs,
+        futures_channel: &WorkflowStepFuturesChannel,
+    ) {
         match result {
             FutureResult::FfmpegEndpointGone => {
                 error!("Ffmpeg endpoint is gone");
@@ -170,25 +182,19 @@ impl FfmpegPullStep {
                 self.stop_ffmpeg();
             }
 
-            FutureResult::RtmpEndpointResponseReceived(response, receiver) => {
-                outputs
-                    .futures
-                    .push(wait_for_rtmp_notification(receiver).boxed());
-
-                self.handle_rtmp_notification(outputs, response);
+            FutureResult::RtmpEndpointResponseReceived(response) => {
+                self.handle_rtmp_notification(outputs, response, &futures_channel);
             }
 
-            FutureResult::FfmpegNotificationReceived(notification, receiver) => {
-                self.handle_ffmpeg_notification(outputs, notification, receiver);
+            FutureResult::FfmpegNotificationReceived(notification) => {
+                self.handle_ffmpeg_notification(notification);
             }
         }
     }
 
     fn handle_ffmpeg_notification(
         &mut self,
-        outputs: &mut StepOutputs,
         message: FfmpegEndpointNotification,
-        receiver: UnboundedReceiver<FfmpegEndpointNotification>,
     ) {
         match message {
             FfmpegEndpointNotification::FfmpegFailedToStart { cause } => {
@@ -200,9 +206,6 @@ impl FfmpegPullStep {
 
             FfmpegEndpointNotification::FfmpegStarted => {
                 info!("Ffmpeg started");
-                outputs
-                    .futures
-                    .push(wait_for_ffmpeg_notification(receiver).boxed());
             }
 
             FfmpegEndpointNotification::FfmpegStopped => {
@@ -215,6 +218,7 @@ impl FfmpegPullStep {
         &mut self,
         outputs: &mut StepOutputs,
         message: RtmpEndpointPublisherMessage,
+        futures_channel: &WorkflowStepFuturesChannel,
     ) {
         match message {
             RtmpEndpointPublisherMessage::PublisherRegistrationFailed => {
@@ -227,7 +231,7 @@ impl FfmpegPullStep {
             RtmpEndpointPublisherMessage::PublisherRegistrationSuccessful => {
                 info!("Publisher registration successful");
                 self.status = StepStatus::Active;
-                self.start_ffmpeg(outputs);
+                self.start_ffmpeg(futures_channel);
             }
 
             RtmpEndpointPublisherMessage::NewPublisherConnected {
@@ -387,7 +391,7 @@ impl FfmpegPullStep {
         }
     }
 
-    fn start_ffmpeg(&mut self, outputs: &mut StepOutputs) {
+    fn start_ffmpeg(&mut self, futures_channel: &WorkflowStepFuturesChannel) {
         if self.ffmpeg_id.is_none() {
             info!("Starting ffmpeg");
             let id = Uuid::new_v4();
@@ -410,9 +414,11 @@ impl FfmpegPullStep {
                     },
                 });
 
-            outputs
-                .futures
-                .push(wait_for_ffmpeg_notification(receiver).boxed());
+            futures_channel.send_on_unbounded_recv(
+                receiver,
+                |notification| FutureResult::FfmpegNotificationReceived(notification),
+                || FutureResult::FfmpegEndpointGone,
+            );
         }
     }
 
@@ -436,10 +442,15 @@ impl WorkflowStep for FfmpegPullStep {
         &self.definition
     }
 
-    fn execute(&mut self, inputs: &mut StepInputs, outputs: &mut StepOutputs) {
+    fn execute(
+        &mut self,
+        inputs: &mut StepInputs,
+        outputs: &mut StepOutputs,
+        futures_channel: WorkflowStepFuturesChannel,
+    ) {
         for result in inputs.notifications.drain(..) {
             if let Ok(result) = result.downcast::<FutureResult>() {
-                self.handle_resolved_future(*result, outputs);
+                self.handle_resolved_future(*result, outputs, &futures_channel);
             }
         }
     }
@@ -457,42 +468,4 @@ impl WorkflowStep for FfmpegPullStep {
                 rtmp_stream_key: StreamKeyRegistration::Exact(self.stream_name.clone()),
             });
     }
-}
-
-async fn notify_rtmp_endpoint_gone(
-    endpoint: UnboundedSender<RtmpEndpointRequest>,
-) -> Box<dyn StepFutureResult> {
-    endpoint.closed().await;
-
-    Box::new(FutureResult::RtmpEndpointGone)
-}
-
-async fn notify_ffmpeg_endpoint_gone(
-    endpoint: UnboundedSender<FfmpegEndpointRequest>,
-) -> Box<dyn StepFutureResult> {
-    endpoint.closed().await;
-
-    Box::new(FutureResult::FfmpegEndpointGone)
-}
-
-async fn wait_for_rtmp_notification(
-    mut receiver: UnboundedReceiver<RtmpEndpointPublisherMessage>,
-) -> Box<dyn StepFutureResult> {
-    let result = match receiver.recv().await {
-        Some(msg) => FutureResult::RtmpEndpointResponseReceived(msg, receiver),
-        None => FutureResult::RtmpEndpointGone,
-    };
-
-    Box::new(result)
-}
-
-async fn wait_for_ffmpeg_notification(
-    mut receiver: UnboundedReceiver<FfmpegEndpointNotification>,
-) -> Box<dyn StepFutureResult> {
-    let result = match receiver.recv().await {
-        Some(msg) => FutureResult::FfmpegNotificationReceived(msg, receiver),
-        None => FutureResult::FfmpegEndpointGone,
-    };
-
-    Box::new(result)
 }

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
@@ -8,7 +8,6 @@ use crate::endpoint::{
     AudioTranscodeParams, FfmpegEndpointRequest, FfmpegParams, TargetParams, VideoTranscodeParams,
 };
 use crate::workflow_steps::ffmpeg_handler::{FfmpegHandlerGenerator, FfmpegParameterGenerator};
-use futures::FutureExt;
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
 use mmids_core::workflows::metadata::MetadataKey;
 use mmids_core::workflows::steps::factory::StepGenerator;
@@ -22,6 +21,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
+use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 
 const TARGET: &str = "target";
 
@@ -73,7 +73,11 @@ impl FfmpegRtmpPushStepGenerator {
 }
 
 impl StepGenerator for FfmpegRtmpPushStepGenerator {
-    fn generate(&self, definition: WorkflowStepDefinition) -> StepCreationResult {
+    fn generate(
+        &self,
+        definition: WorkflowStepDefinition,
+        futures_channel: WorkflowStepFuturesChannel,
+    ) -> StepCreationResult {
         let target = match definition.parameters.get(TARGET) {
             Some(Some(value)) => value,
             _ => return Err(Box::new(StepStartupError::NoTargetProvided)),
@@ -87,12 +91,13 @@ impl StepGenerator for FfmpegRtmpPushStepGenerator {
         let handler_generator =
             FfmpegHandlerGenerator::new(self.ffmpeg_endpoint.clone(), Box::new(param_generator));
 
-        let (reader, mut futures) = ExternalStreamReader::new(
+        let reader = ExternalStreamReader::new(
             Arc::new(format!("ffmpeg-rtmp-push-{}", definition.get_id())),
             self.rtmp_endpoint.clone(),
             Box::new(handler_generator),
             self.is_keyframe_metadata_key,
             self.pts_offset_metadata_key,
+            &futures_channel
         );
 
         let step = FfmpegRtmpPushStep {
@@ -101,9 +106,15 @@ impl StepGenerator for FfmpegRtmpPushStepGenerator {
             stream_reader: reader,
         };
 
-        futures.push(notify_when_ffmpeg_endpoint_is_gone(self.ffmpeg_endpoint.clone()).boxed());
+        let ffmpeg_endpoint = self.ffmpeg_endpoint.clone();
+        futures_channel.send_on_future_completion(
+            async move {
+                ffmpeg_endpoint.closed().await;
+                FutureResult::FfmpegEndpointGone
+            }
+        );
 
-        Ok((Box::new(step), futures))
+        Ok(Box::new(step))
     }
 }
 
@@ -116,7 +127,12 @@ impl WorkflowStep for FfmpegRtmpPushStep {
         &self.definition
     }
 
-    fn execute(&mut self, inputs: &mut StepInputs, outputs: &mut StepOutputs) {
+    fn execute(
+        &mut self,
+        inputs: &mut StepInputs,
+        outputs: &mut StepOutputs,
+        futures_channel: WorkflowStepFuturesChannel,
+    ) {
         if let StepStatus::Error { message } = &self.stream_reader.status {
             error!("External stream reader is in error status, so putting the step in in error status as well.");
 
@@ -132,7 +148,7 @@ impl WorkflowStep for FfmpegRtmpPushStep {
                 Err(future_result) => {
                     // Not a future we can handle
                     self.stream_reader
-                        .handle_resolved_future(future_result, outputs)
+                        .handle_resolved_future(future_result, &futures_channel)
                 }
 
                 Ok(future_result) => match *future_result {
@@ -145,7 +161,7 @@ impl WorkflowStep for FfmpegRtmpPushStep {
         }
 
         for media in inputs.media.drain(..) {
-            self.stream_reader.handle_media(media, outputs);
+            self.stream_reader.handle_media(media, outputs, &futures_channel);
         }
     }
 
@@ -175,10 +191,3 @@ fn get_rtmp_app(id: String) -> String {
     format!("ffmpeg-rtmp-push-{}", id)
 }
 
-async fn notify_when_ffmpeg_endpoint_is_gone(
-    endpoint: UnboundedSender<FfmpegEndpointRequest>,
-) -> Box<dyn StepFutureResult> {
-    endpoint.closed().await;
-
-    Box::new(FutureResult::FfmpegEndpointGone)
-}

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
@@ -231,8 +231,8 @@ impl TestContext {
     }
 }
 
-#[test]
-fn step_starts_in_active_state() {
+#[tokio::test]
+async fn step_starts_in_active_state() {
     let definition = DefinitionBuilder::new().build();
     let context = TestContext::new(definition).unwrap();
 
@@ -240,8 +240,8 @@ fn step_starts_in_active_state() {
     assert_eq!(status, &StepStatus::Active, "Unexpected step status");
 }
 
-#[test]
-fn step_fails_to_build_when_invalid_vcodec_specified() {
+#[tokio::test]
+async fn step_fails_to_build_when_invalid_vcodec_specified() {
     let definition = DefinitionBuilder::new().vcodec("abcdef").build();
 
     match TestContext::new(definition) {
@@ -250,8 +250,8 @@ fn step_fails_to_build_when_invalid_vcodec_specified() {
     }
 }
 
-#[test]
-fn step_fails_to_build_when_no_vcodec_specified() {
+#[tokio::test]
+async fn step_fails_to_build_when_no_vcodec_specified() {
     let mut definition = DefinitionBuilder::new().build();
     definition.parameters.remove(VIDEO_CODEC_NAME);
 
@@ -624,8 +624,8 @@ async fn if_ffmpeg_process_stops_unexpectedly_it_starts_again_with_same_id_and_p
     assert_eq!(new_id, id, "Ids were not equal");
 }
 
-#[test]
-fn stream_started_notification_passed_through_immediately() {
+#[tokio::test]
+async fn stream_started_notification_passed_through_immediately() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -639,8 +639,8 @@ fn stream_started_notification_passed_through_immediately() {
         });
 }
 
-#[test]
-fn disconnection_notification_passed_through_immediately() {
+#[tokio::test]
+async fn disconnection_notification_passed_through_immediately() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -651,8 +651,8 @@ fn disconnection_notification_passed_through_immediately() {
             content: MediaNotificationContent::StreamDisconnected,
         });
 }
-#[test]
-fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -666,8 +666,8 @@ fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
         });
 }
 
-#[test]
-fn video_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn video_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -686,8 +686,8 @@ fn video_notification_passed_as_input_does_not_get_passed_as_output() {
         });
 }
 
-#[test]
-fn audio_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn audio_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 

--- a/mmids-gstreamer/Cargo.toml
+++ b/mmids-gstreamer/Cargo.toml
@@ -14,6 +14,6 @@ gstreamer-app = "0.18.0"
 gstreamer-audio = "0.18.0"
 lazy_static = "1.4.0"
 thiserror = "1.0"
-tokio = "1.15"
+tokio = "1.24"
 tracing = { version = "0.1", features = ["log"] }
 uuid = { version = "0.8.2", features = ["v4"]}

--- a/mmids-rtmp/Cargo.toml
+++ b/mmids-rtmp/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3"
 rml_rtmp = "0.6"
 thiserror = "1.0"
 tokio = {version = "= 1.24", features = ["sync"]}
+tokio-util = "0.7"
 tracing = {version = "0.1", features = ["log"]}
 uuid = {version = "1.2", features = ["v4"]}
 

--- a/mmids-rtmp/Cargo.toml
+++ b/mmids-rtmp/Cargo.toml
@@ -13,7 +13,7 @@ downcast-rs = "1.2"
 futures = "0.3"
 rml_rtmp = "0.6"
 thiserror = "1.0"
-tokio = {version = "= 1.21", features = ["sync"]}
+tokio = {version = "= 1.24", features = ["sync"]}
 tracing = {version = "0.1", features = ["log"]}
 uuid = {version = "1.2", features = ["v4"]}
 

--- a/mmids-rtmp/src/workflow_steps/external_stream_handler.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_handler.rs
@@ -1,7 +1,7 @@
 use downcast_rs::{impl_downcast, Downcast};
+use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 use mmids_core::workflows::steps::StepFutureResult;
 use mmids_core::StreamId;
-use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 
 /// Trait used to handle different external resources for a single stream
 pub trait ExternalStreamHandler {

--- a/mmids-rtmp/src/workflow_steps/external_stream_handler.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_handler.rs
@@ -1,5 +1,5 @@
 use downcast_rs::{impl_downcast, Downcast};
-use mmids_core::workflows::steps::{StepFutureResult, StepOutputs};
+use mmids_core::workflows::steps::StepFutureResult;
 use mmids_core::StreamId;
 use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 
@@ -12,7 +12,6 @@ pub trait ExternalStreamHandler {
     fn handle_resolved_future(
         &mut self,
         future: Box<dyn StreamHandlerFutureResult>,
-        outputs: &mut StepOutputs,
     ) -> ResolvedFutureStatus;
 }
 

--- a/mmids-rtmp/src/workflow_steps/external_stream_handler.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_handler.rs
@@ -1,10 +1,11 @@
 use downcast_rs::{impl_downcast, Downcast};
 use mmids_core::workflows::steps::{StepFutureResult, StepOutputs};
 use mmids_core::StreamId;
+use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 
 /// Trait used to handle different external resources for a single stream
 pub trait ExternalStreamHandler {
-    fn prepare_stream(&mut self, stream_name: &str, outputs: &mut StepOutputs);
+    fn prepare_stream(&mut self, stream_name: &str, futures_channel: &WorkflowStepFuturesChannel);
 
     fn stop_stream(&mut self);
 

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
@@ -247,7 +247,7 @@ impl StepGenerator for RtmpReceiverStepGenerator {
 
         futures_channel.send_on_unbounded_recv(
             receiver,
-            |response| FutureResult::RtmpEndpointResponseReceived(response),
+            FutureResult::RtmpEndpointResponseReceived,
             || FutureResult::RtmpEndpointDroppedRegistration,
         );
 
@@ -318,7 +318,7 @@ impl RtmpReceiverStep {
                     connection_id,
                     ConnectionDetails {
                         stream_id: stream_id.clone(),
-                        cancellation_token: cancellation_token,
+                        cancellation_token,
                     },
                 );
 

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
@@ -253,8 +253,8 @@ async fn error_if_no_key_specified() {
     }
 }
 
-#[test]
-fn step_starts_in_created_state() {
+#[tokio::test]
+async fn step_starts_in_created_state() {
     let definition = DefinitionBuilder::new().build();
     let context = TestContext::new(definition).unwrap();
 
@@ -583,8 +583,8 @@ async fn audio_notification_received_when_publisher_sends_audio() {
     assert_eq!(media.content, expected_content, "Unexpected media content");
 }
 
-#[test]
-fn stream_started_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn stream_started_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -598,8 +598,8 @@ fn stream_started_notification_passed_as_input_does_not_get_passed_as_output() {
         });
 }
 
-#[test]
-fn stream_disconnected_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn stream_disconnected_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -611,8 +611,8 @@ fn stream_disconnected_notification_passed_as_input_does_not_get_passed_as_outpu
         });
 }
 
-#[test]
-fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -626,8 +626,8 @@ fn metadata_notification_passed_as_input_does_not_get_passed_as_output() {
         });
 }
 
-#[test]
-fn video_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn video_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 
@@ -646,8 +646,8 @@ fn video_notification_passed_as_input_does_not_get_passed_as_output() {
         });
 }
 
-#[test]
-fn audio_notification_passed_as_input_does_not_get_passed_as_output() {
+#[tokio::test]
+async fn audio_notification_passed_as_input_does_not_get_passed_as_output() {
     let definition = DefinitionBuilder::new().build();
     let mut context = TestContext::new(definition).unwrap();
 

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
@@ -258,7 +258,7 @@ impl StepGenerator for RtmpWatchStepGenerator {
 
         futures_channel.send_on_unbounded_recv(
             notification_receiver,
-            |message| RtmpWatchStepFutureResult::RtmpWatchNotificationReceived(message),
+            RtmpWatchStepFutureResult::RtmpWatchNotificationReceived,
             || RtmpWatchStepFutureResult::RtmpEndpointGone,
         );
 

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
@@ -270,8 +270,8 @@ fn error_if_no_stream_key_provided() {
     }
 }
 
-#[test]
-fn new_step_is_in_created_status() {
+#[tokio::test]
+async fn new_step_is_in_created_status() {
     let definition = DefinitionBuilder::new().build();
     let context = TestContext::new(definition).unwrap();
 

--- a/reactor-test-server/Cargo.toml
+++ b/reactor-test-server/Cargo.toml
@@ -10,5 +10,5 @@ futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.15", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/validators/echo-server/Cargo.toml
+++ b/validators/echo-server/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 mmids-core = {path = "../../mmids-core"}
 bytes = "1"
-tokio = { version = "1.9", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 env_logger = "0.9.0"
 log = "0.4"
 futures = "0.3"

--- a/validators/ffmpeg-runner/Cargo.toml
+++ b/validators/ffmpeg-runner/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 mmids-core = {path = "../../mmids-core"}
 mmids-ffmpeg = {path = "../../mmids-ffmpeg"}
 
-tokio = { version = "1.15", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 env_logger = "0.9.0"
 log = "0.4"
 uuid = { version = "1.2", features = ["v4"] }

--- a/validators/rtmp-server/Cargo.toml
+++ b/validators/rtmp-server/Cargo.toml
@@ -10,7 +10,7 @@ mmids-core = {path = "../../mmids-core"}
 mmids-rtmp = {path = "../../mmids-rtmp"}
 
 bytes = "1"
-tokio = { version = "1.9", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 env_logger = "0.9.0"
 log = "0.4"
 futures = "0.3"


### PR DESCRIPTION
Previously, workflow steps would box up their futures and return them to the workflow runner for execution.  This caused excessive allocations for every future and added extra steps to getting that future to run.

Instead, the API has been refactored to allow the workflow runner to pass workflow steps a channel it can send the results of the step's futures to.  This allows workflow steps to spawn their own tasks for their own futures, and only involve the workflow runner when a result has been computed.  

This also helps the ergonomics of writing workflow steps, as each future result doesn't need to pass back the receiver to restart the future.  Instead they can continually recv from a receiver in a single future until the channel is closed.