### PR TITLE
Create workflow step futures media channel

### DIFF
--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -196,6 +196,25 @@ impl Actor {
                         FuturesChannelInnerResult::Generic(result) => {
                             self.execute_steps(step_id, Some(result), false, true);
                         }
+
+                        FuturesChannelInnerResult::Media(media) => {
+                            // Handle the media as if it came as an output of a normal step execution
+                            self.step_outputs.clear();
+                            self.step_outputs.media.push(media);
+                            self.handle_executed_step_outputs(step_id);
+
+                            // If this came from an active step, then we need to start executing
+                            // inputs from the *next* step after the one that produced this media.
+                            // This works because `handle_executed_step_outputs` takes outputs
+                            // and puts them properly into inputs, thus allowing us to just
+                            // execute the next step normally.
+                            if let Some(step_index) = self.get_active_step_index(step_id) {
+                                let next_step_index = step_index + 1;
+                                if let Some(next_step_id) = self.active_steps.get(next_step_index) {
+                                    self.execute_steps(*next_step_id, None, true, false);
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -407,17 +426,10 @@ impl Actor {
             self.step_inputs.notifications.push(future_result);
         }
 
-        let mut start_index = None;
-        for x in 0..self.active_steps.len() {
-            if self.active_steps[x] == initial_step_id {
-                start_index = Some(x);
-                break;
-            }
-        }
-
         // If we have a start_index, that means the step we want to execute is an active step.  So
         // execute that step and all active steps after it. If it's not an active step, then we
         // only want to execute that one step and none others.
+        let start_index = self.get_active_step_index(initial_step_id);
         if let Some(start_index) = start_index {
             for x in start_index..self.active_steps.len() {
                 self.execute_step(self.active_steps[x]);
@@ -461,12 +473,7 @@ impl Actor {
             return;
         }
 
-        self.update_stream_details(step_id);
-        self.update_media_cache_from_outputs(step_id);
-        self.step_inputs.clear();
-        self.step_inputs.media.append(&mut self.step_outputs.media);
-
-        self.step_outputs.clear();
+        self.handle_executed_step_outputs(step_id);
     }
 
     fn check_if_all_pending_steps_are_active(&mut self, swap_if_pending_is_empty: bool) {
@@ -735,5 +742,23 @@ impl Actor {
                 step.shutdown();
             }
         }
+    }
+
+    fn get_active_step_index(&self, step_id: WorkflowStepId) -> Option<usize> {
+        for x in 0..self.active_steps.len() {
+            if self.active_steps[x] == step_id {
+                return Some(x);
+            }
+        }
+
+        None
+    }
+
+    fn handle_executed_step_outputs(&mut self, step_id: WorkflowStepId) {
+        self.update_stream_details(step_id);
+        self.update_media_cache_from_outputs(step_id);
+        self.step_inputs.clear();
+        self.step_inputs.media.append(&mut self.step_outputs.media);
+        self.step_outputs.clear();
     }
 }

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -745,13 +745,7 @@ impl Actor {
     }
 
     fn get_active_step_index(&self, step_id: WorkflowStepId) -> Option<usize> {
-        for x in 0..self.active_steps.len() {
-            if self.active_steps[x] == step_id {
-                return Some(x);
-            }
-        }
-
-        None
+        (0..self.active_steps.len()).find(|&index| self.active_steps[index] == step_id)
     }
 
     fn handle_executed_step_outputs(&mut self, step_id: WorkflowStepId) {

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 use crate::actor_utils::notify_on_unbounded_recv;
 use crate::workflows::definitions::{WorkflowDefinition, WorkflowStepDefinition, WorkflowStepId};
 use crate::workflows::steps::factory::WorkflowStepFactory;
-use crate::workflows::steps::futures_channel::{StepFutureResultChannel, WorkflowStepFuturesChannel};
+use crate::workflows::steps::futures_channel::{FuturesChannelResult, WorkflowStepFuturesChannel};
 use crate::workflows::steps::{
     StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
 };
@@ -116,7 +116,7 @@ struct Actor {
     step_factory: Arc<WorkflowStepFactory>,
     step_definitions: HashMap<WorkflowStepId, WorkflowStepDefinition>,
     status: WorkflowStatus,
-    step_futures_sender: UnboundedSender<StepFutureResultChannel>,
+    step_futures_sender: UnboundedSender<FuturesChannelResult>,
 }
 
 impl Actor {
@@ -138,7 +138,7 @@ impl Actor {
         notify_on_unbounded_recv(
             futures_receiver,
             actor_sender,
-            |result: StepFutureResultChannel| FutureResult::StepFutureResolved {
+            |result: FuturesChannelResult| FutureResult::StepFutureResolved {
                 step_id: result.step_id,
                 result: result.result,
             },

--- a/mmids-core/src/workflows/runner/mod.rs
+++ b/mmids-core/src/workflows/runner/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 use crate::actor_utils::notify_on_unbounded_recv;
 use crate::workflows::definitions::{WorkflowDefinition, WorkflowStepDefinition, WorkflowStepId};
 use crate::workflows::steps::factory::WorkflowStepFactory;
-use crate::workflows::steps::futures_channel::{FuturesChannelResult, WorkflowStepFuturesChannel};
+use crate::workflows::steps::futures_channel::{StepFutureResultChannel, WorkflowStepFuturesChannel};
 use crate::workflows::steps::{
     StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
 };
@@ -116,7 +116,7 @@ struct Actor {
     step_factory: Arc<WorkflowStepFactory>,
     step_definitions: HashMap<WorkflowStepId, WorkflowStepDefinition>,
     status: WorkflowStatus,
-    step_futures_sender: UnboundedSender<FuturesChannelResult>,
+    step_futures_sender: UnboundedSender<StepFutureResultChannel>,
 }
 
 impl Actor {
@@ -138,7 +138,7 @@ impl Actor {
         notify_on_unbounded_recv(
             futures_receiver,
             actor_sender,
-            |result: FuturesChannelResult| FutureResult::StepFutureResolved {
+            |result: StepFutureResultChannel| FutureResult::StepFutureResolved {
                 step_id: result.step_id,
                 result: result.result,
             },

--- a/mmids-core/src/workflows/runner/test_context.rs
+++ b/mmids-core/src/workflows/runner/test_context.rs
@@ -9,8 +9,8 @@ use crate::workflows::{
 };
 use crate::StreamId;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU16;
+use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::watch::{channel, Sender};
 

--- a/mmids-core/src/workflows/runner/test_steps.rs
+++ b/mmids-core/src/workflows/runner/test_steps.rs
@@ -191,7 +191,7 @@ fn input_media_received(
     receiver: Receiver<MediaNotification>,
     futures_channel: &WorkflowStepFuturesChannel,
 ) {
-    futures_channel.send_on_watch_recv(
+    futures_channel.send_on_generic_watch_recv(
         receiver,
         |_| InputFutureResult::MediaReceived,
         || InputFutureResult::MediaChannelClosed,
@@ -202,7 +202,7 @@ fn input_status_received(
     receiver: Receiver<StepStatus>,
     futures_channel: &WorkflowStepFuturesChannel,
 ) {
-    futures_channel.send_on_watch_recv(
+    futures_channel.send_on_generic_watch_recv(
         receiver,
         |_| InputFutureResult::StatusReceived,
         || InputFutureResult::StatusChannelClosed,
@@ -213,7 +213,7 @@ fn output_status_received(
     receiver: Receiver<StepStatus>,
     futures_channel: &WorkflowStepFuturesChannel,
 ) {
-    futures_channel.send_on_watch_recv(
+    futures_channel.send_on_generic_watch_recv(
         receiver,
         |_| OutputFutureResult::StatusReceived,
         || OutputFutureResult::StatusChannelClosed,

--- a/mmids-core/src/workflows/runner/test_steps.rs
+++ b/mmids-core/src/workflows/runner/test_steps.rs
@@ -1,12 +1,14 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, Ordering};
 use crate::workflows::definitions::WorkflowStepDefinition;
 use crate::workflows::steps::factory::StepGenerator;
-use crate::workflows::steps::futures_channel::{FuturesChannelInnerResult, WorkflowStepFuturesChannel};
+use crate::workflows::steps::futures_channel::{
+    FuturesChannelInnerResult, WorkflowStepFuturesChannel,
+};
 use crate::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
 };
 use crate::workflows::MediaNotification;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::watch::Receiver;
 
@@ -147,9 +149,7 @@ impl WorkflowStep for TestInputStep {
                 }
 
                 InputFutureResult::FutureResultMediaReceived(media) => {
-                    let _ = futures_channel.send(
-                        FuturesChannelInnerResult::Media(media)
-                    );
+                    let _ = futures_channel.send(FuturesChannelInnerResult::Media(media));
                 }
 
                 InputFutureResult::FutureResultMediaChannelClosed => {
@@ -162,6 +162,7 @@ impl WorkflowStep for TestInputStep {
 
         for media in inputs.media.drain(..) {
             outputs.media.push(media); // for workflow forwarding tests
+            self.media_received_count.fetch_add(1, Ordering::SeqCst);
         }
     }
 

--- a/mmids-core/src/workflows/runner/tests.rs
+++ b/mmids-core/src/workflows/runner/tests.rs
@@ -8,8 +8,8 @@ use crate::workflows::{
 };
 use crate::{test_utils, StreamId};
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot::channel;
 use tokio::time::timeout;
@@ -271,8 +271,6 @@ async fn media_sent_to_workflow_flows_through_steps() {
         MediaNotificationContent::StreamDisconnected => (),
         x => panic!("Unexpected media notification: {:?}", x),
     }
-    let count = context.input_step_media_received_count.load(Ordering::SeqCst);
-    assert_eq!(count, 1, "Expected no media received by first step")
 }
 
 #[tokio::test]
@@ -573,7 +571,7 @@ async fn workflow_in_error_state_if_updated_steps_arent_registered_with_factory(
 }
 
 #[tokio::test]
-async fn media_future_result_from_active_step_goes_to_next_step() {
+async fn media_future_result_from_active_step_immediately_goes_to_next_step() {
     let mut context = TestContext::new();
 
     context
@@ -591,7 +589,7 @@ async fn media_future_result_from_active_step_goes_to_next_step() {
         stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
             stream_name: Arc::new("def".to_string()),
-        }
+        },
     };
 
     context
@@ -602,7 +600,9 @@ async fn media_future_result_from_active_step_goes_to_next_step() {
     let response = test_utils::expect_mpsc_response(&mut context.output_step_media_receiver).await;
     assert_eq!(media, response, "Unexpected media packet");
 
-    let count = context.input_step_media_received_count.load(Ordering::Acquire);
+    let count = context
+        .input_step_media_received_count
+        .load(Ordering::Acquire);
     assert_eq!(count, 0, "Expected no media received by first step")
 }
 
@@ -625,7 +625,7 @@ async fn media_future_result_from_pending_step_does_not_go_to_next_step() {
         stream_id: StreamId(Arc::new("abc".to_string())),
         content: MediaNotificationContent::NewIncomingStream {
             stream_name: Arc::new("def".to_string()),
-        }
+        },
     };
 
     context

--- a/mmids-core/src/workflows/steps/factory.rs
+++ b/mmids-core/src/workflows/steps/factory.rs
@@ -1,5 +1,5 @@
 use crate::workflows::definitions::{WorkflowStepDefinition, WorkflowStepType};
-use crate::workflows::steps::futures_channel::{FuturesChannelResult, WorkflowStepFuturesChannel};
+use crate::workflows::steps::futures_channel::{StepFutureResultChannel, WorkflowStepFuturesChannel};
 use crate::workflows::steps::StepCreationResult;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -63,7 +63,7 @@ impl WorkflowStepFactory {
     pub(crate) fn create_step(
         &self,
         definition: WorkflowStepDefinition,
-        futures_channel: &UnboundedSender<FuturesChannelResult>,
+        futures_channel: &UnboundedSender<StepFutureResultChannel>,
     ) -> Result<StepCreationResult, FactoryCreateError> {
         let generator = match self.generators.get(&definition.step_type) {
             Some(generator) => generator,

--- a/mmids-core/src/workflows/steps/factory.rs
+++ b/mmids-core/src/workflows/steps/factory.rs
@@ -1,5 +1,5 @@
 use crate::workflows::definitions::{WorkflowStepDefinition, WorkflowStepType};
-use crate::workflows::steps::futures_channel::{StepFutureResultChannel, WorkflowStepFuturesChannel};
+use crate::workflows::steps::futures_channel::{FuturesChannelResult, WorkflowStepFuturesChannel};
 use crate::workflows::steps::StepCreationResult;
 use std::collections::HashMap;
 use thiserror::Error;
@@ -63,7 +63,7 @@ impl WorkflowStepFactory {
     pub(crate) fn create_step(
         &self,
         definition: WorkflowStepDefinition,
-        futures_channel: &UnboundedSender<StepFutureResultChannel>,
+        futures_channel: &UnboundedSender<FuturesChannelResult>,
     ) -> Result<StepCreationResult, FactoryCreateError> {
         let generator = match self.generators.get(&definition.step_type) {
             Some(generator) => generator,

--- a/mmids-core/src/workflows/steps/futures_channel.rs
+++ b/mmids-core/src/workflows/steps/futures_channel.rs
@@ -7,62 +7,40 @@ use crate::workflows::steps::StepFutureResult;
 use std::future::Future;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_util::sync::CancellationToken;
-use crate::workflows::MediaNotification;
 
 /// An channel which can be used by workflow steps to send future completion results to the
 /// workflow runner.
 #[derive(Clone)]
 pub struct WorkflowStepFuturesChannel {
     step_id: WorkflowStepId,
-    step_future_result_sender: UnboundedSender<StepFutureResultChannel>,
-    media_result_sender: UnboundedSender<FuturesMediaChannelResult>,
+    sender: UnboundedSender<FuturesChannelResult>,
 }
 
-/// The type of information that's returned to the workflow runner upon a future's completion
-pub struct StepFutureResultChannel {
+/// The type of information that's returned to the workflow upon a future's completion
+pub struct FuturesChannelResult {
     pub step_id: WorkflowStepId,
     pub result: Box<dyn StepFutureResult>,
 }
 
-/// The type of information that's returned to the workflow runner when a future completes with a
-/// media result. This is separate from normal workflow step future results, as we will not need
-/// to box the media up since it's a defined type.
-pub struct FuturesMediaChannelResult {
-    pub step_id: WorkflowStepId,
-    pub media: MediaNotification,
-}
-
 impl WorkflowStepFuturesChannel {
-    pub fn new(
-        step_id: WorkflowStepId,
-        step_future_result_sender: UnboundedSender<StepFutureResultChannel>,
-        media_result_sender: UnboundedSender<FuturesMediaChannelResult>,
-    ) -> Self {
-        WorkflowStepFuturesChannel { step_id, step_future_result_sender, media_result_sender }
+    pub fn new(step_id: WorkflowStepId, sender: UnboundedSender<FuturesChannelResult>) -> Self {
+        WorkflowStepFuturesChannel { step_id, sender }
     }
 
     /// Sends the workflow step's future result over the channel. Returns an error if the channel
     /// is closed.
-    pub fn send_step_future_result(
-        &self,
-        message: impl StepFutureResult,
-    ) -> Result<(), Box<dyn StepFutureResult>> {
-        let message = StepFutureResultChannel {
+    pub fn send(&self, message: impl StepFutureResult) -> Result<(), Box<dyn StepFutureResult>> {
+        let message = FuturesChannelResult {
             step_id: self.step_id,
             result: Box::new(message),
         };
 
-        self.step_future_result_sender.send(message).map_err(|e| e.0.result)
+        self.sender.send(message).map_err(|e| e.0.result)
     }
 
-    /// Completes when the channel is closed due to there being no receiver.
+    /// Completes when the channel is closed due to there being no receiver
     pub async fn closed(&self) {
-        // It's not valid for only one of these channels to be open, so consider the channel closed
-        // when at least one channel is closed.
-        tokio::select! {
-            _ = self.step_future_result_sender.closed() => (),
-            _ = self.media_result_sender.closed() => (),
-        }
+        self.sender.closed().await
     }
 
     /// Helper function for workflow steps to watch a receiver for messages, and send them back
@@ -84,12 +62,12 @@ impl WorkflowStepFuturesChannel {
                         match message {
                             Some(message) => {
                                 let future_result = on_recv(message);
-                                let _ = channel.send_step_future_result(future_result);
+                                let _ = channel.send(future_result);
                             }
 
                             None => {
                                 let future_result = on_closed();
-                                let _ = channel.send_step_future_result(future_result);
+                                let _ = channel.send(future_result);
                                 break;
                             }
                         }
@@ -124,12 +102,12 @@ impl WorkflowStepFuturesChannel {
                         match message {
                             Some(message) => {
                                 let future_result = on_recv(message);
-                                let _ = channel.send_step_future_result(future_result);
+                                let _ = channel.send(future_result);
                             }
 
                             None => {
                                 let future_result = on_closed();
-                                let _ = channel.send_step_future_result(future_result);
+                                let _ = channel.send(future_result);
                                 break;
                             }
                         }
@@ -137,7 +115,7 @@ impl WorkflowStepFuturesChannel {
 
                     _ = cancellation_token.cancelled() => {
                         let future_result = on_cancelled();
-                        let _ = channel.send_step_future_result(future_result);
+                        let _ = channel.send(future_result);
                         break;
                     }
 
@@ -170,12 +148,12 @@ impl WorkflowStepFuturesChannel {
                             Ok(_) => {
                                 let value = receiver.borrow();
                                 let future_result = on_recv(&value);
-                                let _ = channel.send_step_future_result(future_result);
+                                let _ = channel.send(future_result);
                             }
 
                             Err(_) => {
                                 let future_result = on_closed();
-                                let _ = channel.send_step_future_result(future_result);
+                                let _ = channel.send(future_result);
                                 break;
                             }
                         }
@@ -198,7 +176,7 @@ impl WorkflowStepFuturesChannel {
         tokio::spawn(async move {
             tokio::select! {
                 result = future => {
-                    let _ = channel.send_step_future_result(result);
+                    let _ = channel.send(result);
                 }
 
                 _ = channel.closed() => {

--- a/mmids-core/src/workflows/steps/futures_channel.rs
+++ b/mmids-core/src/workflows/steps/futures_channel.rs
@@ -4,6 +4,7 @@
 
 use crate::workflows::definitions::WorkflowStepId;
 use crate::workflows::steps::StepFutureResult;
+use crate::workflows::MediaNotification;
 use std::future::Future;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio_util::sync::CancellationToken;
@@ -27,6 +28,11 @@ pub enum FuturesChannelInnerResult {
     /// Declares the result is a type that implements the `StepFutureResult` trait, and therefore
     /// is only readable by the raising step itself.
     Generic(Box<dyn StepFutureResult>),
+
+    /// The result of the future is a strongly typed media notification that is ready to be passed
+    /// on to the next step in the workflow. Media notifications raised in this manner *will not*
+    /// be passed back to the step whose future produced it.
+    Media(MediaNotification),
 }
 
 impl WorkflowStepFuturesChannel {

--- a/mmids-core/src/workflows/steps/futures_channel.rs
+++ b/mmids-core/src/workflows/steps/futures_channel.rs
@@ -19,7 +19,14 @@ pub struct WorkflowStepFuturesChannel {
 /// The type of information that's returned to the workflow upon a future's completion
 pub struct FuturesChannelResult {
     pub step_id: WorkflowStepId,
-    pub result: Box<dyn StepFutureResult>,
+    pub result: FuturesChannelInnerResult,
+}
+
+/// The type of result being sent over the future channel
+pub enum FuturesChannelInnerResult {
+    /// Declares the result is a type that implements the `StepFutureResult` trait, and therefore
+    /// is only readable by the raising step itself.
+    Generic(Box<dyn StepFutureResult>),
 }
 
 impl WorkflowStepFuturesChannel {
@@ -29,10 +36,13 @@ impl WorkflowStepFuturesChannel {
 
     /// Sends the workflow step's future result over the channel. Returns an error if the channel
     /// is closed.
-    pub fn send(&self, message: impl StepFutureResult) -> Result<(), Box<dyn StepFutureResult>> {
+    pub fn send(
+        &self,
+        message: FuturesChannelInnerResult,
+    ) -> Result<(), FuturesChannelInnerResult> {
         let message = FuturesChannelResult {
             step_id: self.step_id,
-            result: Box::new(message),
+            result: message,
         };
 
         self.sender.send(message).map_err(|e| e.0.result)
@@ -45,7 +55,9 @@ impl WorkflowStepFuturesChannel {
 
     /// Helper function for workflow steps to watch a receiver for messages, and send them back
     /// to the workflow step for processing.
-    pub fn send_on_unbounded_recv<ReceiverMessage, FutureResult>(
+    ///
+    /// This only sends a generic `StepFutureResult` value.
+    pub fn send_on_generic_unbounded_recv<ReceiverMessage, FutureResult>(
         &self,
         mut receiver: UnboundedReceiver<ReceiverMessage>,
         on_recv: impl Fn(ReceiverMessage) -> FutureResult + Send + 'static,
@@ -61,12 +73,18 @@ impl WorkflowStepFuturesChannel {
                     message = receiver.recv() => {
                         match message {
                             Some(message) => {
-                                let future_result = on_recv(message);
+                                let future_result = FuturesChannelInnerResult::Generic(
+                                    Box::new(on_recv(message))
+                                );
+
                                 let _ = channel.send(future_result);
                             }
 
                             None => {
-                                let future_result = on_closed();
+                                let future_result = FuturesChannelInnerResult::Generic(
+                                    Box::new(on_closed())
+                                );
+
                                 let _ = channel.send(future_result);
                                 break;
                             }
@@ -83,7 +101,9 @@ impl WorkflowStepFuturesChannel {
 
     /// Helper function for workflow steps to watch a receiver for messages, and send them back
     /// to the workflow step for processing. Cancellable via a token.
-    pub fn send_on_unbounded_recv_cancellable<ReceiverMessage, FutureResult>(
+    ///
+    /// This only sends a generic `StepFutureResult` value.
+    pub fn send_on_generic_unbounded_recv_cancellable<ReceiverMessage, FutureResult>(
         &self,
         mut receiver: UnboundedReceiver<ReceiverMessage>,
         cancellation_token: CancellationToken,
@@ -101,12 +121,18 @@ impl WorkflowStepFuturesChannel {
                     message = receiver.recv() => {
                         match message {
                             Some(message) => {
-                                let future_result = on_recv(message);
+                                let future_result = FuturesChannelInnerResult::Generic(
+                                    Box::new(on_recv(message))
+                                );
+
                                 let _ = channel.send(future_result);
                             }
 
                             None => {
-                                let future_result = on_closed();
+                                let future_result = FuturesChannelInnerResult::Generic(
+                                    Box::new(on_closed())
+                                );
+
                                 let _ = channel.send(future_result);
                                 break;
                             }
@@ -114,7 +140,10 @@ impl WorkflowStepFuturesChannel {
                     }
 
                     _ = cancellation_token.cancelled() => {
-                        let future_result = on_cancelled();
+                        let future_result = FuturesChannelInnerResult::Generic(
+                            Box::new(on_cancelled())
+                        );
+
                         let _ = channel.send(future_result);
                         break;
                     }
@@ -130,7 +159,9 @@ impl WorkflowStepFuturesChannel {
 
     /// Helper function for workflow steps to track a tokio watch receiver for messages, and send
     /// them back to the workflow step for processing.
-    pub fn send_on_watch_recv<ReceiverMessage, FutureResult>(
+    ///
+    /// This only sends a generic `StepFutureResult` value.
+    pub fn send_on_generic_watch_recv<ReceiverMessage, FutureResult>(
         &self,
         mut receiver: tokio::sync::watch::Receiver<ReceiverMessage>,
         on_recv: impl Fn(&ReceiverMessage) -> FutureResult + Send + 'static,
@@ -147,12 +178,18 @@ impl WorkflowStepFuturesChannel {
                         match message {
                             Ok(_) => {
                                 let value = receiver.borrow();
-                                let future_result = on_recv(&value);
+                                let future_result = FuturesChannelInnerResult::Generic(
+                                   Box::new(on_recv(&value))
+                                );
+
                                 let _ = channel.send(future_result);
                             }
 
                             Err(_) => {
-                                let future_result = on_closed();
+                                let future_result = FuturesChannelInnerResult::Generic(
+                                    Box::new(on_closed())
+                                );
+
                                 let _ = channel.send(future_result);
                                 break;
                             }
@@ -167,8 +204,10 @@ impl WorkflowStepFuturesChannel {
         });
     }
 
-    /// Helper function for workflow steps to easily send a message upon future completion
-    pub fn send_on_future_completion(
+    /// Helper function for workflow steps to easily send a message upon future completion.
+    ///
+    /// This only sends a generic `StepFutureResult` value.
+    pub fn send_on_generic_future_completion(
         &self,
         future: impl Future<Output = impl StepFutureResult + Send> + Send + 'static,
     ) {
@@ -176,7 +215,7 @@ impl WorkflowStepFuturesChannel {
         tokio::spawn(async move {
             tokio::select! {
                 result = future => {
-                    let _ = channel.send(result);
+                    let _ = channel.send(FuturesChannelInnerResult::Generic(Box::new(result)));
                 }
 
                 _ = channel.closed() => {

--- a/mmids-core/src/workflows/steps/mod.rs
+++ b/mmids-core/src/workflows/steps/mod.rs
@@ -108,7 +108,7 @@ pub trait WorkflowStep {
 #[cfg(feature = "test-utils")]
 use crate::workflows::steps::factory::StepGenerator;
 #[cfg(feature = "test-utils")]
-use crate::workflows::steps::futures_channel::FuturesChannelResult;
+use crate::workflows::steps::futures_channel::StepFutureResultChannel;
 use crate::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 #[cfg(feature = "test-utils")]
 use anyhow::{anyhow, Result};
@@ -124,7 +124,7 @@ pub struct StepTestContext {
     pub step: Box<dyn WorkflowStep>,
     pub media_outputs: Vec<MediaNotification>,
     pub futures_channel_sender: WorkflowStepFuturesChannel,
-    futures_channel_receiver: UnboundedReceiver<FuturesChannelResult>,
+    futures_channel_receiver: UnboundedReceiver<StepFutureResultChannel>,
 }
 
 #[cfg(feature = "test-utils")]

--- a/mmids-core/src/workflows/steps/mod.rs
+++ b/mmids-core/src/workflows/steps/mod.rs
@@ -108,7 +108,7 @@ pub trait WorkflowStep {
 #[cfg(feature = "test-utils")]
 use crate::workflows::steps::factory::StepGenerator;
 #[cfg(feature = "test-utils")]
-use crate::workflows::steps::futures_channel::StepFutureResultChannel;
+use crate::workflows::steps::futures_channel::FuturesChannelResult;
 use crate::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
 #[cfg(feature = "test-utils")]
 use anyhow::{anyhow, Result};
@@ -124,7 +124,7 @@ pub struct StepTestContext {
     pub step: Box<dyn WorkflowStep>,
     pub media_outputs: Vec<MediaNotification>,
     pub futures_channel_sender: WorkflowStepFuturesChannel,
-    futures_channel_receiver: UnboundedReceiver<StepFutureResultChannel>,
+    futures_channel_receiver: UnboundedReceiver<FuturesChannelResult>,
 }
 
 #[cfg(feature = "test-utils")]

--- a/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/mod.rs
@@ -181,7 +181,7 @@ impl WorkflowForwarderStep {
                 {
                     let channel = channel.clone();
                     let name = name.clone();
-                    futures_channel.send_on_future_completion(async move {
+                    futures_channel.send_on_generic_future_completion(async move {
                         channel.closed().await;
                         FutureResult::WorkflowGone {
                             workflow_name: name,
@@ -263,7 +263,7 @@ impl WorkflowForwarderStep {
 
                         let stream_id = media.stream_id.clone();
                         let stream_name = stream_name.clone();
-                        futures_channel.send_on_future_completion(async move {
+                        futures_channel.send_on_generic_future_completion(async move {
                             let result = match receiver.recv().await {
                                 Some(response) => response,
                                 None => ReactorWorkflowUpdate {
@@ -617,7 +617,7 @@ fn notify_on_workflow_event(
     receiver: UnboundedReceiver<WorkflowStartedOrStoppedEvent>,
     futures_channel: &WorkflowStepFuturesChannel,
 ) {
-    futures_channel.send_on_unbounded_recv(
+    futures_channel.send_on_generic_unbounded_recv(
         receiver,
         FutureResult::WorkflowStartedOrStopped,
         || FutureResult::EventHubGone,
@@ -632,7 +632,7 @@ fn notify_on_reactor_update(
 ) {
     let recv_stream_id = stream_id.clone();
     let cancelled_stream_id = stream_id;
-    futures_channel.send_on_unbounded_recv_cancellable(
+    futures_channel.send_on_generic_unbounded_recv_cancellable(
         update_receiver,
         cancellation_token,
         move |update| FutureResult::ReactorUpdateReceived {
@@ -650,7 +650,7 @@ fn notify_reactor_manager_gone(
     sender: UnboundedSender<ReactorManagerRequest>,
     futures_channel: &WorkflowStepFuturesChannel,
 ) {
-    futures_channel.send_on_future_completion(async move {
+    futures_channel.send_on_generic_future_completion(async move {
         sender.closed().await;
         FutureResult::ReactorManagerGone
     });

--- a/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::test_utils;
 use crate::workflows::definitions::WorkflowStepType;
 use crate::workflows::metadata::MediaPayloadMetadataCollection;
-use crate::workflows::steps::StepTestContext;
+use crate::workflows::steps::{FuturesChannelInnerResult, StepTestContext};
 use crate::workflows::MediaType;
 use anyhow::{anyhow, Result};
 use bytes::{Bytes, BytesMut};
@@ -91,7 +91,11 @@ impl TestContext {
             .expect("Failed to send workflow started event");
 
         let result = self.step_context.expect_future_resolved().await;
-        self.step_context.execute_notification(result).await;
+        match result {
+            FuturesChannelInnerResult::Generic(result) => {
+                self.step_context.execute_notification(result).await;
+            }
+        }
     }
 
     async fn send_workflow_stopped_event(&mut self, name: &str) {
@@ -102,7 +106,11 @@ impl TestContext {
             .expect("Failed to send workflow ended event");
 
         let result = self.step_context.expect_future_resolved().await;
-        self.step_context.execute_notification(result).await;
+        match result {
+            FuturesChannelInnerResult::Generic(result) => {
+                self.step_context.execute_notification(result).await;
+            }
+        }
     }
 }
 

--- a/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
+++ b/mmids-core/src/workflows/steps/workflow_forwarder/tests.rs
@@ -95,6 +95,10 @@ impl TestContext {
             FuturesChannelInnerResult::Generic(result) => {
                 self.step_context.execute_notification(result).await;
             }
+
+            FuturesChannelInnerResult::Media(_) => {
+                panic!("Expected a generic step future result but instead got media packet");
+            }
         }
     }
 
@@ -109,6 +113,10 @@ impl TestContext {
         match result {
             FuturesChannelInnerResult::Generic(result) => {
                 self.step_context.execute_notification(result).await;
+            }
+
+            FuturesChannelInnerResult::Media(_) => {
+                panic!("Expected a generic step future result but instead got media packet");
             }
         }
     }

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
@@ -185,7 +185,7 @@ mod tests {
     use super::*;
     use crate::endpoint::{AudioTranscodeParams, TargetParams, VideoTranscodeParams};
     use mmids_core::workflows::definitions::WorkflowStepId;
-    use mmids_core::workflows::steps::futures_channel::FuturesChannelResult;
+    use mmids_core::workflows::steps::futures_channel::StepFutureResultChannel;
     use tokio::sync::mpsc::UnboundedReceiver;
 
     struct TestParamGenerator;
@@ -209,7 +209,7 @@ mod tests {
         ffmpeg: UnboundedReceiver<FfmpegEndpointRequest>,
         handler: Box<dyn ExternalStreamHandler>,
         step_futures_channel: WorkflowStepFuturesChannel,
-        _step_futures_receiver: UnboundedReceiver<FuturesChannelResult>,
+        _step_futures_receiver: UnboundedReceiver<StepFutureResultChannel>,
     }
 
     impl TestContext {

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
@@ -185,7 +185,7 @@ mod tests {
     use super::*;
     use crate::endpoint::{AudioTranscodeParams, TargetParams, VideoTranscodeParams};
     use mmids_core::workflows::definitions::WorkflowStepId;
-    use mmids_core::workflows::steps::futures_channel::StepFutureResultChannel;
+    use mmids_core::workflows::steps::futures_channel::FuturesChannelResult;
     use tokio::sync::mpsc::UnboundedReceiver;
 
     struct TestParamGenerator;
@@ -209,7 +209,7 @@ mod tests {
         ffmpeg: UnboundedReceiver<FfmpegEndpointRequest>,
         handler: Box<dyn ExternalStreamHandler>,
         step_futures_channel: WorkflowStepFuturesChannel,
-        _step_futures_receiver: UnboundedReceiver<StepFutureResultChannel>,
+        _step_futures_receiver: UnboundedReceiver<FuturesChannelResult>,
     }
 
     impl TestContext {

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_handler.rs
@@ -126,7 +126,7 @@ impl ExternalStreamHandler for FfmpegHandler {
 
             let recv_stream_id = self.stream_id.clone();
             let closed_stream_id = self.stream_id.clone();
-            futures_channel.send_on_unbounded_recv(
+            futures_channel.send_on_generic_unbounded_recv(
                 receiver,
                 move |notification| StreamHandlerFutureWrapper {
                     stream_id: recv_stream_id.clone(),

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_hls/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_hls/mod.rs
@@ -157,12 +157,12 @@ impl StepGenerator for FfmpegHlsStepGenerator {
         };
 
         let ffmpeg_endpoint = self.ffmpeg_endpoint.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             ffmpeg_endpoint.closed().await;
             FutureResult::FfmpegEndpointGone
         });
 
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             let result = tokio::fs::create_dir_all(&path).await;
             FutureResult::HlsPathCreated(result)
         });

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_pull/mod.rs
@@ -140,12 +140,12 @@ impl StepGenerator for FfmpegPullStepGenerator {
             });
 
         let ffmpeg_endpoint = self.ffmpeg_endpoint.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             ffmpeg_endpoint.closed().await;
             FutureResult::FfmpegEndpointGone
         });
 
-        futures_channel.send_on_unbounded_recv(
+        futures_channel.send_on_generic_unbounded_recv(
             receiver,
             FutureResult::RtmpEndpointResponseReceived,
             || FutureResult::RtmpEndpointGone,
@@ -408,7 +408,7 @@ impl FfmpegPullStep {
                     },
                 });
 
-            futures_channel.send_on_unbounded_recv(
+            futures_channel.send_on_generic_unbounded_recv(
                 receiver,
                 FutureResult::FfmpegNotificationReceived,
                 || FutureResult::FfmpegEndpointGone,

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_rtmp_push/mod.rs
@@ -107,7 +107,7 @@ impl StepGenerator for FfmpegRtmpPushStepGenerator {
         };
 
         let ffmpeg_endpoint = self.ffmpeg_endpoint.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             ffmpeg_endpoint.closed().await;
             FutureResult::FfmpegEndpointGone
         });

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/mod.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/mod.rs
@@ -285,13 +285,13 @@ impl StepGenerator for FfmpegTranscoderStepGenerator {
         };
 
         let ffmpeg_endpoint = self.ffmpeg_endpoint.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             ffmpeg_endpoint.closed().await;
             FutureResult::FfmpegEndpointGone
         });
 
         let rtmp_endpoint = self.rtmp_server_endpoint.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             rtmp_endpoint.closed().await;
             FutureResult::RtmpEndpointGone
         });
@@ -510,7 +510,7 @@ impl FfmpegTranscoder {
 
                     let recv_stream_id = stream.id.clone();
                     let closed_stream_id = stream.id.clone();
-                    futures_channel.send_on_unbounded_recv(
+                    futures_channel.send_on_generic_unbounded_recv(
                         watch_receiver,
                         move |message| {
                             FutureResult::RtmpWatchNotificationReceived(
@@ -572,7 +572,7 @@ impl FfmpegTranscoder {
 
                     let recv_stream_id = stream.id.clone();
                     let closed_stream_id = stream.id.clone();
-                    futures_channel.send_on_unbounded_recv(
+                    futures_channel.send_on_generic_unbounded_recv(
                         receiver,
                         move |message| {
                             FutureResult::RtmpPublishNotificationReceived(
@@ -618,7 +618,7 @@ impl FfmpegTranscoder {
 
                     let recv_stream_id = stream.id.clone();
                     let closed_stream_id = stream.id.clone();
-                    futures_channel.send_on_unbounded_recv(
+                    futures_channel.send_on_generic_unbounded_recv(
                         receiver,
                         move |message| {
                             FutureResult::FfmpegNotificationReceived(

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
@@ -183,7 +183,7 @@ impl TestContext {
             request => panic!("Unexpected rtmp request seen: {:?}", request),
         };
 
-        self.step_context.execute_pending_notifications().await;
+        self.step_context.execute_pending_futures().await;
 
         channels
     }
@@ -206,7 +206,7 @@ impl TestContext {
             request => panic!("Unexpected rtmp request seen: {:?}", request),
         };
 
-        self.step_context.execute_pending_notifications().await;
+        self.step_context.execute_pending_futures().await;
 
         channel
     }
@@ -616,7 +616,7 @@ async fn if_ffmpeg_process_stops_unexpectedly_it_starts_again_with_same_id_and_p
         .send(FfmpegEndpointNotification::FfmpegStopped)
         .expect("Failed to send ffmpeg stopped command");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let (_channel, new_params, new_id) = context.process_ffmpeg_event().await;
 
@@ -822,7 +822,7 @@ async fn metadata_packet_sent_to_watcher_media_channel() {
     };
 
     context.step_context.execute_with_media(media.clone());
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let response = test_utils::expect_mpsc_response(&mut media_channel).await;
     assert_eq!(response.stream_key.as_str(), "abc", "Unexpected stream key");
@@ -900,7 +900,7 @@ async fn video_packet_from_publisher_passed_as_media_output() {
         })
         .expect("Failed to send video message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),
@@ -988,7 +988,7 @@ async fn audio_packet_from_publisher_passed_as_media_output() {
         })
         .expect("Failed to send video message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),
@@ -1038,7 +1038,7 @@ async fn metadata_packet_from_publisher_passed_as_media_output() {
         })
         .expect("Failed to send video message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),

--- a/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
+++ b/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
@@ -126,7 +126,7 @@ impl StepGenerator for BasicTranscodeStepGenerator {
         };
 
         let transcode_endpoint = self.transcode_endpoint.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             transcode_endpoint.closed().await;
             FutureResult::TranscoderEndpointGone
         });
@@ -201,7 +201,7 @@ impl BasicTranscodeStep {
             });
 
         let closed_stream_id = stream_id.clone();
-        futures_channel.send_on_unbounded_recv(
+        futures_channel.send_on_generic_unbounded_recv(
             notification_receiver,
             move |notification| FutureResult::TranscoderNotificationReceived {
                 stream_id: stream_id.clone(),
@@ -270,7 +270,7 @@ impl BasicTranscodeStep {
 
             GstTranscoderNotification::TranscodingStarted { output_media } => {
                 let closed_stream_id = stream_id.clone();
-                futures_channel.send_on_unbounded_recv(
+                futures_channel.send_on_generic_unbounded_recv(
                     output_media,
                     move |media| FutureResult::TranscodedMediaReceived {
                         stream_id: stream_id.clone(),

--- a/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
+++ b/mmids-gstreamer/src/steps/basic_transcoder/mod.rs
@@ -12,7 +12,9 @@ use crate::endpoints::gst_transcoder::{
 };
 use mmids_core::workflows::definitions::WorkflowStepDefinition;
 use mmids_core::workflows::steps::factory::StepGenerator;
-use mmids_core::workflows::steps::futures_channel::WorkflowStepFuturesChannel;
+use mmids_core::workflows::steps::futures_channel::{
+    FuturesChannelInnerResult, WorkflowStepFuturesChannel,
+};
 use mmids_core::workflows::steps::{
     StepCreationResult, StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
 };
@@ -60,10 +62,6 @@ enum FutureResult {
     },
 
     TranscodedMediaChannelClosed(StreamId),
-    TranscodedMediaReceived {
-        stream_id: StreamId,
-        media: MediaNotificationContent,
-    },
 }
 
 impl StepFutureResult for FutureResult {}
@@ -270,13 +268,20 @@ impl BasicTranscodeStep {
 
             GstTranscoderNotification::TranscodingStarted { output_media } => {
                 let closed_stream_id = stream_id.clone();
-                futures_channel.send_on_generic_unbounded_recv(
+
+                futures_channel.send_on_unbounded_recv(
                     output_media,
-                    move |media| FutureResult::TranscodedMediaReceived {
-                        stream_id: stream_id.clone(),
-                        media,
+                    move |media| {
+                        FuturesChannelInnerResult::Media(MediaNotification {
+                            stream_id: stream_id.clone(),
+                            content: media,
+                        })
                     },
-                    move || FutureResult::TranscodedMediaChannelClosed(closed_stream_id),
+                    move || {
+                        FuturesChannelInnerResult::Generic(Box::new(
+                            FutureResult::TranscodedMediaChannelClosed(closed_stream_id),
+                        ))
+                    },
                 );
             }
         }
@@ -346,13 +351,6 @@ impl WorkflowStep for BasicTranscodeStep {
                     stream_id,
                 } => {
                     self.handle_transcode_notification(stream_id, notification, &futures_channel);
-                }
-
-                FutureResult::TranscodedMediaReceived { media, stream_id } => {
-                    outputs.media.push(MediaNotification {
-                        stream_id,
-                        content: media,
-                    });
                 }
             }
         }

--- a/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
@@ -536,6 +536,10 @@ mod tests {
                     self.external_stream_reader
                         .handle_resolved_future(result, &self.futures_channel);
                 }
+
+                FuturesChannelInnerResult::Media(_) => {
+                    panic!("Expected a generic step future result but instead got media packet");
+                }
             }
 
             media_channel
@@ -821,6 +825,10 @@ mod tests {
                 context
                     .external_stream_reader
                     .handle_resolved_future(result, &context.futures_channel);
+            }
+
+            FuturesChannelInnerResult::Media(_) => {
+                panic!("Expected a generic step future result but instead got media packet");
             }
         }
 

--- a/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
@@ -405,7 +405,7 @@ mod tests {
     use mmids_core::workflows::metadata::{
         MediaPayloadMetadataCollection, MetadataEntry, MetadataKeyMap, MetadataValue,
     };
-    use mmids_core::workflows::steps::futures_channel::FuturesChannelResult;
+    use mmids_core::workflows::steps::futures_channel::StepFutureResultChannel;
     use mmids_core::workflows::MediaType;
     use mmids_core::{test_utils, VideoTimestamp};
     use rml_rtmp::time::RtmpTimestamp;
@@ -420,7 +420,7 @@ mod tests {
         rtmp_endpoint: UnboundedReceiver<RtmpEndpointRequest>,
         prepare_stream_receiver: UnboundedReceiver<String>,
         stop_stream_receiver: UnboundedReceiver<()>,
-        futures_channel_receiver: UnboundedReceiver<FuturesChannelResult>,
+        futures_channel_receiver: UnboundedReceiver<StepFutureResultChannel>,
         futures_channel: WorkflowStepFuturesChannel,
     }
 

--- a/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
@@ -405,7 +405,7 @@ mod tests {
     use mmids_core::workflows::metadata::{
         MediaPayloadMetadataCollection, MetadataEntry, MetadataKeyMap, MetadataValue,
     };
-    use mmids_core::workflows::steps::futures_channel::StepFutureResultChannel;
+    use mmids_core::workflows::steps::futures_channel::FuturesChannelResult;
     use mmids_core::workflows::MediaType;
     use mmids_core::{test_utils, VideoTimestamp};
     use rml_rtmp::time::RtmpTimestamp;
@@ -420,7 +420,7 @@ mod tests {
         rtmp_endpoint: UnboundedReceiver<RtmpEndpointRequest>,
         prepare_stream_receiver: UnboundedReceiver<String>,
         stop_stream_receiver: UnboundedReceiver<()>,
-        futures_channel_receiver: UnboundedReceiver<StepFutureResultChannel>,
+        futures_channel_receiver: UnboundedReceiver<FuturesChannelResult>,
         futures_channel: WorkflowStepFuturesChannel,
     }
 

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/mod.rs
@@ -245,14 +245,14 @@ impl StepGenerator for RtmpReceiverStepGenerator {
                 requires_registrant_approval: step.reactor_name.is_some(),
             });
 
-        futures_channel.send_on_unbounded_recv(
+        futures_channel.send_on_generic_unbounded_recv(
             receiver,
             FutureResult::RtmpEndpointResponseReceived,
             || FutureResult::RtmpEndpointDroppedRegistration,
         );
 
         let reactor_manager = self.reactor_manager.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             reactor_manager.closed().await;
             FutureResult::ReactorManagerGone
         });
@@ -298,7 +298,7 @@ impl RtmpReceiverStep {
                 let cancellation_token = if let Some(update_channel) = reactor_update_channel {
                     let cancellation_token = CancellationToken::new();
                     let connection_id = connection_id.clone();
-                    futures_channel.send_on_unbounded_recv_cancellable(
+                    futures_channel.send_on_generic_unbounded_recv_cancellable(
                         update_channel,
                         cancellation_token.child_token(),
                         move |update| FutureResult::ReactorUpdateReceived {
@@ -446,7 +446,7 @@ impl RtmpReceiverStep {
                     );
 
                     // Start a future waiting for reactor's response
-                    futures_channel.send_on_future_completion(async move {
+                    futures_channel.send_on_generic_future_completion(async move {
                         let is_valid = match receiver.recv().await {
                             Some(response) => response.is_valid,
                             None => false, // reactor closed, treat it the same as no workflow scenario

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
@@ -148,7 +148,7 @@ impl TestContext {
             request => panic!("Unexpected rtmp request seen: {:?}", request),
         };
 
-        self.step_context.execute_pending_notifications().await;
+        self.step_context.execute_pending_futures().await;
 
         channel
     }
@@ -282,7 +282,7 @@ async fn registration_failure_sets_status_to_error() {
         request => panic!("Unexpected rtmp request seen: {:?}", request),
     };
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let status = context.step_context.step.get_status();
     match status {
@@ -311,7 +311,7 @@ async fn registration_success_sets_status_to_active() {
         request => panic!("Unexpected rtmp request seen: {:?}", request),
     };
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let status = context.step_context.step.get_status();
     match status {
@@ -335,7 +335,7 @@ async fn stream_started_notification_raised_when_publisher_connects() {
         })
         .expect("Failed to send publisher connected message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),
@@ -370,7 +370,7 @@ async fn stream_disconnected_notification_raised_when_publisher_disconnects() {
         })
         .expect("Failed to send publisher connected message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
     context.step_context.media_outputs.clear();
 
     channel
@@ -379,7 +379,7 @@ async fn stream_disconnected_notification_raised_when_publisher_disconnects() {
         })
         .expect("Failed to send disconnected message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),
@@ -411,7 +411,7 @@ async fn metadata_notification_raised_when_publisher_sends_one() {
         })
         .expect("Failed to send publisher connected message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let mut metadata = StreamMetadata::new();
     metadata.video_width = Some(1920);
@@ -423,7 +423,7 @@ async fn metadata_notification_raised_when_publisher_sends_one() {
         })
         .expect("Failed to send metadata message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),
@@ -462,7 +462,7 @@ async fn video_notification_received_when_publisher_sends_video() {
         })
         .expect("Failed to send publisher connected message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     channel
         .send(RtmpEndpointPublisherMessage::NewVideoData {
@@ -475,7 +475,7 @@ async fn video_notification_received_when_publisher_sends_video() {
         })
         .expect("Failed to send video message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),
@@ -549,7 +549,7 @@ async fn audio_notification_received_when_publisher_sends_audio() {
         })
         .expect("Failed to send publisher connected message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     channel
         .send(RtmpEndpointPublisherMessage::NewAudioData {
@@ -560,7 +560,7 @@ async fn audio_notification_received_when_publisher_sends_audio() {
         })
         .expect("Failed to send audio message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     assert_eq!(
         context.step_context.media_outputs.len(),
@@ -701,7 +701,7 @@ async fn reactor_queried_for_stream_key_when_approval_required() {
         })
         .expect("Failed to send publisher message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let request = test_utils::expect_mpsc_response(&mut context.reactor_manager).await;
     match request {
@@ -733,7 +733,7 @@ async fn rejection_sent_when_reactor_says_stream_is_not_valid() {
         })
         .expect("Failed to send publisher message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
     let reactor_channel = context.get_reactor_channel().await;
 
     reactor_channel
@@ -743,7 +743,7 @@ async fn rejection_sent_when_reactor_says_stream_is_not_valid() {
         })
         .expect("Failed to send reactor response");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let response = test_utils::expect_oneshot_response(receiver).await;
     match response {
@@ -767,7 +767,7 @@ async fn approval_sent_when_reactor_says_stream_is_valid() {
         })
         .expect("Failed to send publisher message");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
     let reactor_channel = context.get_reactor_channel().await;
 
     reactor_channel
@@ -777,7 +777,7 @@ async fn approval_sent_when_reactor_says_stream_is_valid() {
         })
         .expect("Failed to send reactor response");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let response = test_utils::expect_oneshot_response(receiver).await;
     match response {

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/mod.rs
@@ -256,14 +256,14 @@ impl StepGenerator for RtmpWatchStepGenerator {
                 requires_registrant_approval: step.reactor_name.is_some(),
             });
 
-        futures_channel.send_on_unbounded_recv(
+        futures_channel.send_on_generic_unbounded_recv(
             notification_receiver,
             RtmpWatchStepFutureResult::RtmpWatchNotificationReceived,
             || RtmpWatchStepFutureResult::RtmpEndpointGone,
         );
 
         let reactor_manager = self.reactor_manager.clone();
-        futures_channel.send_on_future_completion(async move {
+        futures_channel.send_on_generic_future_completion(async move {
             reactor_manager.closed().await;
             RtmpWatchStepFutureResult::ReactorManagerGone
         });
@@ -305,7 +305,7 @@ impl RtmpWatchStep {
                         let cancellation_token = CancellationToken::new();
                         let recv_stream_key = stream_key.clone();
                         let cancelled_stream_key = stream_key.clone();
-                        futures_channel.send_on_unbounded_recv_cancellable(
+                        futures_channel.send_on_generic_unbounded_recv_cancellable(
                             reactor_update_channel,
                             cancellation_token.child_token(),
                             move |update| RtmpWatchStepFutureResult::ReactorUpdateReceived {
@@ -355,7 +355,7 @@ impl RtmpWatchStep {
                         },
                     );
 
-                    futures_channel.send_on_future_completion(async move {
+                    futures_channel.send_on_generic_future_completion(async move {
                         let is_valid = match receiver.recv().await {
                             Some(response) => response.is_valid,
                             None => false, // Assume not valid if channel closed

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
@@ -161,7 +161,7 @@ impl TestContext {
             request => panic!("Unexpected rtmp request seen: {:?}", request),
         };
 
-        self.step_context.execute_pending_notifications().await;
+        self.step_context.execute_pending_futures().await;
 
         channel
     }
@@ -300,7 +300,7 @@ async fn registration_failure_changes_status_to_error() {
         response => panic!("Unexpected response: {:?}", response),
     };
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let status = context.step_context.step.get_status();
     match status {
@@ -330,7 +330,7 @@ async fn registration_success_changes_status_to_active() {
         response => panic!("Unexpected response: {:?}", response),
     };
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let status = context.step_context.step.get_status();
     match status {
@@ -705,7 +705,7 @@ async fn watchers_requiring_approval_sends_request_to_reactor() {
         })
         .expect("Failed to send approval request");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let request = test_utils::expect_mpsc_response(&mut context.reactor_manager).await;
     match request {
@@ -743,7 +743,7 @@ async fn reactor_responding_with_invalid_sends_rejection_response() {
         })
         .expect("Failed to send approval request");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let reactor_channel = context.get_reactor_channel().await;
     reactor_channel
@@ -753,7 +753,7 @@ async fn reactor_responding_with_invalid_sends_rejection_response() {
         })
         .expect("Failed to send reactor response");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
     let response = test_utils::expect_oneshot_response(receiver).await;
     match response {
         ValidationResponse::Reject => (),
@@ -778,7 +778,7 @@ async fn reactor_responding_with_valid_sends_approved_response() {
         })
         .expect("Failed to send approval request");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
 
     let reactor_channel = context.get_reactor_channel().await;
     reactor_channel
@@ -788,7 +788,7 @@ async fn reactor_responding_with_valid_sends_approved_response() {
         })
         .expect("Failed to send reactor response");
 
-    context.step_context.execute_pending_notifications().await;
+    context.step_context.execute_pending_futures().await;
     let response = test_utils::expect_oneshot_response(receiver).await;
     match response {
         ValidationResponse::Approve { .. } => (),


### PR DESCRIPTION
When a workflow step receives media from an endpoint, it always gets each media notification from a future, usually from a tokio channel. This means each media payload comes back to the workflow step as a `Box<dyn StepFutureResult>`, and needs to be unpacked and manually placed into the workflow's `StepOutputs.media` vector by the step.  

Not only does this cause extra steps when creating workflow steps, but it also means that *every* media packet must be boxed, causing unnecessary heap copying and allocations.

This PR updates the workflow step futures channel to allow transferring strongly typed media packets as part of a completed future. This allows a workflow step to designate that a future returns media packets destined for the next step, thus removing the need for boxing and removing the need for workflow steps to manually move media packets around to get them to the next step.  

Note that while this is implemented from an API standpoint, and verified via workflow runner tests, this isn't utilized by most of the built in workflow steps (except the gstreamer transcoding one). This is because most workflow steps built in utilize the RTMP endpoint, which needs to be refactored to take advantage of this new pattern (and that's out of scope for this PR, but will come later).