### PR TITLE
Redesign workflow step traits

### DIFF
--- a/mmids-core/src/workflows/steps/factory.rs
+++ b/mmids-core/src/workflows/steps/factory.rs
@@ -7,7 +7,9 @@ use tokio::sync::mpsc::UnboundedSender;
 
 /// Represents a type that can generate an instance of a workflow step
 pub trait StepGenerator {
-    /// Creates a brand new instance of a workflow step based on the supplied definition
+    /// Creates a brand new instance of a workflow step based on the supplied definition. Generating
+    /// a workflow step returns both the workflow step itself as well as the initial status the
+    /// step should be in.
     fn generate(
         &self,
         definition: WorkflowStepDefinition,

--- a/mmids-core/src/workflows/steps/test_utils.rs
+++ b/mmids-core/src/workflows/steps/test_utils.rs
@@ -5,7 +5,9 @@ use crate::workflows::steps::futures_channel::{
 };
 
 use crate::workflows::definitions::WorkflowStepDefinition;
-use crate::workflows::steps::{StepFutureResult, StepInputs, StepOutputs, WorkflowStep};
+use crate::workflows::steps::{
+    StepFutureResult, StepInputs, StepOutputs, StepStatus, WorkflowStep,
+};
 use crate::workflows::MediaNotification;
 use anyhow::{anyhow, Result};
 use std::time::Duration;
@@ -14,6 +16,7 @@ use tokio::time::timeout;
 
 pub struct StepTestContext {
     pub step: Box<dyn WorkflowStep>,
+    pub status: StepStatus,
     pub media_outputs: Vec<MediaNotification>,
     pub futures_channel_sender: WorkflowStepFuturesChannel,
     futures_channel_receiver: UnboundedReceiver<FuturesChannelResult>,
@@ -27,12 +30,13 @@ impl StepTestContext {
         let (sender, receiver) = unbounded_channel();
         let channel = WorkflowStepFuturesChannel::new(definition.get_id(), sender);
 
-        let (step, _status) = generator
+        let (step, status) = generator
             .generate(definition, channel.clone())
             .map_err(|error| anyhow!("Failed to generate workflow step: {:?}", error))?;
 
         Ok(StepTestContext {
             step,
+            status,
             media_outputs: Vec::new(),
             futures_channel_sender: channel,
             futures_channel_receiver: receiver,
@@ -44,13 +48,14 @@ impl StepTestContext {
         let mut inputs = StepInputs::new();
         inputs.media.push(media);
 
-        self.step.execute(
+        let status = self.step.execute(
             &mut inputs,
             &mut outputs,
             self.futures_channel_sender.clone(),
         );
 
         self.media_outputs = outputs.media;
+        self.status = status;
     }
 
     pub async fn execute_notification(&mut self, notification: Box<dyn StepFutureResult>) {
@@ -58,12 +63,14 @@ impl StepTestContext {
         let mut inputs = StepInputs::new();
         inputs.notifications.push(notification);
 
-        self.step.execute(
+        let status = self.step.execute(
             &mut inputs,
             &mut outputs,
             self.futures_channel_sender.clone(),
         );
+
         self.media_outputs = outputs.media;
+        self.status = status;
 
         self.execute_pending_futures().await;
     }
@@ -100,13 +107,14 @@ impl StepTestContext {
                 }
             };
 
-            self.step.execute(
+            let status = self.step.execute(
                 &mut inputs,
                 &mut outputs,
                 self.futures_channel_sender.clone(),
             );
 
             self.media_outputs.extend(outputs.media);
+            self.status = status;
         }
     }
 

--- a/mmids-core/src/workflows/steps/test_utils.rs
+++ b/mmids-core/src/workflows/steps/test_utils.rs
@@ -27,7 +27,7 @@ impl StepTestContext {
         let (sender, receiver) = unbounded_channel();
         let channel = WorkflowStepFuturesChannel::new(definition.get_id(), sender);
 
-        let step = generator
+        let (step, _status) = generator
             .generate(definition, channel.clone())
             .map_err(|error| anyhow!("Failed to generate workflow step: {:?}", error))?;
 

--- a/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
+++ b/mmids-ffmpeg/src/workflow_steps/ffmpeg_transcode/tests.rs
@@ -237,8 +237,8 @@ async fn step_starts_in_active_state() {
     let definition = DefinitionBuilder::new().build();
     let context = TestContext::new(definition).unwrap();
 
-    let status = context.step_context.step.get_status();
-    assert_eq!(status, &StepStatus::Active, "Unexpected step status");
+    let status = context.step_context.status;
+    assert_eq!(status, StepStatus::Active, "Unexpected step status");
 }
 
 #[tokio::test]

--- a/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
+++ b/mmids-rtmp/src/workflow_steps/external_stream_reader.rs
@@ -390,6 +390,12 @@ impl ExternalStreamReader {
     }
 }
 
+impl Drop for ExternalStreamReader {
+    fn drop(&mut self) {
+        self.stop_all_streams();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_receive/tests.rs
@@ -258,8 +258,8 @@ async fn step_starts_in_created_state() {
     let definition = DefinitionBuilder::new().build();
     let context = TestContext::new(definition).unwrap();
 
-    let status = context.step_context.step.get_status();
-    assert_eq!(status, &StepStatus::Created, "Unexpected step status");
+    let status = context.step_context.status;
+    assert_eq!(status, StepStatus::Created, "Unexpected step status");
 }
 
 #[tokio::test]
@@ -284,7 +284,7 @@ async fn registration_failure_sets_status_to_error() {
 
     context.step_context.execute_pending_futures().await;
 
-    let status = context.step_context.step.get_status();
+    let status = context.step_context.status;
     match status {
         StepStatus::Error { message: _ } => (),
         _ => panic!("Unexpected status: {:?}", status),
@@ -313,7 +313,7 @@ async fn registration_success_sets_status_to_active() {
 
     context.step_context.execute_pending_futures().await;
 
-    let status = context.step_context.step.get_status();
+    let status = context.step_context.status;
     match status {
         StepStatus::Active => (),
         _ => panic!("Unexpected status: {:?}", status),

--- a/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
+++ b/mmids-rtmp/src/workflow_steps/rtmp_watch/tests.rs
@@ -275,8 +275,8 @@ async fn new_step_is_in_created_status() {
     let definition = DefinitionBuilder::new().build();
     let context = TestContext::new(definition).unwrap();
 
-    let status = context.step_context.step.get_status();
-    assert_eq!(status, &StepStatus::Created, "Unexpected step status");
+    let status = context.step_context.status;
+    assert_eq!(status, StepStatus::Created, "Unexpected step status");
 }
 
 #[tokio::test]
@@ -302,7 +302,7 @@ async fn registration_failure_changes_status_to_error() {
 
     context.step_context.execute_pending_futures().await;
 
-    let status = context.step_context.step.get_status();
+    let status = context.step_context.status;
     match status {
         StepStatus::Error { message: _ } => (),
         _ => panic!("Unexpected status: {:?}", status),
@@ -332,7 +332,7 @@ async fn registration_success_changes_status_to_active() {
 
     context.step_context.execute_pending_futures().await;
 
-    let status = context.step_context.step.get_status();
+    let status = context.step_context.status;
     match status {
         StepStatus::Active => (),
         _ => panic!("Unexpected status: {:?}", status),


### PR DESCRIPTION
The workflow step trait was previously designed to be queryable even when it entered an error or shutdown state.  This caused a lot of boilerplate with simple steps, and made it easy to accidentally leak resources by not handling a shutdown incorrectly.  It also gave uncertainty that execute might accidentally be called when it's in the wrong state.

This is now fixed so that the aspects we might query about a workflow step (its definition and it's status specifically) are separate. When a step is created or executed it returns a status, and if that status is an error state then it gets shut down.

Shutting down a workflow step is now just a matter of dropping it, which makes it much easier to automatically clean up after itself once a step is no longer being used (intentionally or not).